### PR TITLE
Pin Typer and Click versions for CLI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ version = "0.1.0"
 description = "Prototype scaffolding for the Lecture Tools application"
 requires-python = ">=3.11"
 dependencies = [
-    "typer>=0.9",
+    "typer==0.12.5",
+    "click==8.1.7",
     "Pillow>=10.0",
     "PyMuPDF>=1.23",
     "faster-whisper>=0.10",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest>=7.4
-typer>=0.9
+typer==0.12.5
+click==8.1.7
 Pillow>=10.0
 PyMuPDF>=1.23
 faster-whisper>=0.10


### PR DESCRIPTION
## Summary
- pin Typer and Click versions in project metadata to versions that support Literal type parameters
- update development requirements to use the same Typer and Click pins so local installs stay consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd94da63d48330b64fb6069585a5eb