### PR TITLE
Fix overview style option compatibility

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from enum import Enum
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
 import typer
 
@@ -30,10 +31,16 @@ def _prepare_logging(storage_root: Path) -> None:
     configure_logging(handlers=[file_handler, stream_handler])
 
 
+
+class UIStyle(str, Enum):
+    MODERN = "modern"
+    CONSOLE = "console"
+
+
 @cli.command()
 def overview(
-    style: Literal["modern", "console"] = typer.Option(
-        "modern",
+    style: UIStyle = typer.Option(
+        UIStyle.MODERN,
         "--style",
         "-s",
         help="Select the overview presentation style.",
@@ -46,7 +53,7 @@ def overview(
     _prepare_logging(config.storage_root)
 
     repository = LectureRepository(config)
-    ui = ModernUI(repository) if style == "modern" else ConsoleUI(repository)
+    ui = ModernUI(repository) if style is UIStyle.MODERN else ConsoleUI(repository)
     ui.run()
 
 


### PR DESCRIPTION
## Summary
- replace the overview style option's `Literal` annotation with a Typer-compatible Enum
- update the UI selection logic to use the Enum values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd95de5d90833095525ce53fda28bb