### PR TITLE
Revamp desktop UI with theming and asset management

### DIFF
--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -1,0 +1,59 @@
+"""Persistence helpers for user interface settings."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+from ..config import AppConfig
+
+
+ThemeName = Literal["dark", "light"]
+
+
+@dataclass
+class UISettings:
+    """Container for customisable UI options."""
+
+    theme: ThemeName = "dark"
+    whisper_model: str = "base"
+    whisper_compute_type: str = "int8"
+    whisper_beam_size: int = 5
+    slide_dpi: int = 200
+
+
+class SettingsStore:
+    """Load and store :class:`UISettings` alongside other persisted assets."""
+
+    def __init__(self, config: AppConfig) -> None:
+        self._config = config
+        self._path = config.storage_root / "settings.json"
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def load(self) -> UISettings:
+        if not self._path.exists():
+            return UISettings()
+
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return UISettings()
+
+        settings = UISettings()
+        for field, value in payload.items():
+            if hasattr(settings, field):
+                setattr(settings, field, value)
+        return settings
+
+    def save(self, settings: UISettings) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = asdict(settings)
+        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+__all__ = ["SettingsStore", "ThemeName", "UISettings"]

--- a/app/ui/desktop.py
+++ b/app/ui/desktop.py
@@ -1,12 +1,24 @@
-"""Tkinter-powered desktop interface for browsing stored lectures."""
+"""Tkinter-powered desktop interface for browsing and managing stored lectures."""
+
+"""Tkinter desktop interface offering modern styling and asset management tools."""
 
 from __future__ import annotations
 
+import os
+import platform
+import shutil
+import subprocess
 import tkinter as tk
-from tkinter import messagebox, ttk
-from typing import Dict, Tuple
+from datetime import datetime
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+from typing import Callable, Dict, List, Optional, Tuple
 
-from ..services.storage import LectureRepository
+from ..config import AppConfig
+from ..processing import FasterWhisperTranscription, PyMuPDFSlideConverter
+from ..services.ingestion import LecturePaths
+from ..services.settings import SettingsStore, ThemeName, UISettings
+from ..services.storage import ClassRecord, LectureRecord, LectureRepository, ModuleRecord
 from .overview import (
     ASSET_LABELS,
     ClassOverview,
@@ -17,22 +29,40 @@ from .overview import (
 )
 
 
-class DesktopUI:
-    """Create a modern-looking desktop window for the lecture overview."""
+Palette = Dict[str, str]
 
-    def __init__(self, repository: LectureRepository) -> None:
+
+class DesktopUI:
+    """Create a polished desktop window for navigating lectures and assets."""
+
+    def __init__(self, repository: LectureRepository, *, config: Optional[AppConfig] = None) -> None:
         self._repository = repository
+        self._config = config
         self._tree: ttk.Treeview | None = None
         self._root: tk.Tk | None = None
-        self._tree_items: Dict[str, Tuple[str, object]] = {}
+        self._tree_items: Dict[str, Tuple[str, object | None, ModuleOverview | None, ClassOverview | None]] = {}
         self._asset_container: ttk.Frame | None = None
 
         self._title_var: tk.StringVar | None = None
         self._subtitle_var: tk.StringVar | None = None
         self._description_var: tk.StringVar | None = None
         self._asset_text_var: tk.StringVar | None = None
+        self._theme_button_text: tk.StringVar | None = None
 
         self._stat_vars: dict[str, tk.StringVar] = {}
+
+        self._settings_store: SettingsStore | None = None
+        self._settings: UISettings = UISettings()
+        self._current_theme: ThemeName = "dark"
+
+        if self._config is not None:
+            self._settings_store = SettingsStore(self._config)
+            self._settings = self._settings_store.load()
+            self._current_theme = self._settings.theme
+
+        self._selected_lecture_id: Optional[int] = None
+        self._active_class: ClassOverview | None = None
+        self._active_module: ModuleOverview | None = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -42,14 +72,15 @@ class DesktopUI:
 
         self._root = root = tk.Tk()
         root.title("Lecture Tools Overview")
-        root.geometry("1100x700")
-        root.minsize(900, 600)
+        root.geometry("1200x760")
+        root.minsize(960, 640)
 
         self._title_var = tk.StringVar(master=root, value="Browse your classes")
         self._subtitle_var = tk.StringVar(
             master=root, value="Select a class, module, or lecture to see details."
         )
         self._description_var = tk.StringVar(master=root, value="")
+        self._theme_button_text = tk.StringVar(master=root)
 
         style = ttk.Style(root)
         try:
@@ -57,7 +88,9 @@ class DesktopUI:
         except tk.TclError:
             pass
 
-        self._configure_styles(style)
+        palette = self._get_palette(self._current_theme)
+        self._configure_styles(style, palette)
+        root.configure(background=palette["background"])
 
         container = ttk.Frame(root, padding=24, style="Main.TFrame")
         container.pack(fill=tk.BOTH, expand=True)
@@ -67,61 +100,151 @@ class DesktopUI:
         self._build_content(container, snapshot)
         self._build_status(container)
 
+        self._update_theme_button()
+
         root.mainloop()
 
     # ------------------------------------------------------------------
     # Layout helpers
     # ------------------------------------------------------------------
-    def _configure_styles(self, style: ttk.Style) -> None:
-        background = "#0f172a"
-        surface = "#1f2937"
-        accent = "#38bdf8"
-        subtle = "#94a3b8"
-        text = "#f8fafc"
+    def _configure_styles(self, style: ttk.Style, palette: Palette) -> None:
+        background = palette["background"]
+        surface = palette["surface"]
+        accent = palette["accent"]
+        subtle = palette["subtle"]
+        text = palette["text"]
+        muted = palette["muted"]
 
         style.configure("Main.TFrame", background=background)
         style.configure("Stats.TFrame", background=background)
-        style.configure("Card.TFrame", background=surface, relief="flat")
-        style.configure("CardTitle.TLabel", background=surface, foreground=subtle, font=("Segoe UI", 11))
+        style.configure(
+            "Card.TFrame",
+            background=surface,
+            relief="flat",
+            borderwidth=0,
+            padding=18,
+        )
+        style.configure(
+            "CardTitle.TLabel",
+            background=surface,
+            foreground=subtle,
+            font=("Segoe UI", 11),
+        )
         style.configure(
             "CardValue.TLabel",
             background=surface,
             foreground=text,
-            font=("Segoe UI", 20, "bold"),
+            font=("Segoe UI", 22, "bold"),
         )
         style.configure("Content.TFrame", background=background)
-        style.configure("Panel.TFrame", background=surface)
-        style.configure("PanelHeading.TLabel", background=surface, foreground=text, font=("Segoe UI", 14, "bold"))
-        style.configure("PanelBody.TFrame", background=surface)
-        style.configure("DetailTitle.TLabel", background=surface, foreground=text, font=("Segoe UI", 18, "bold"))
-        style.configure("DetailSubtitle.TLabel", background=surface, foreground=subtle, font=("Segoe UI", 12))
-        style.configure("DetailText.TLabel", background=surface, foreground=text, font=("Segoe UI", 11), wraplength=420)
+        style.configure("Panel.TFrame", background=surface, relief="flat")
         style.configure(
-            "Card.TButton",
+            "PanelHeading.TLabel",
+            background=surface,
+            foreground=text,
+            font=("Segoe UI", 14, "bold"),
+        )
+        style.configure("PanelBody.TFrame", background=surface)
+        style.configure(
+            "DetailTitle.TLabel",
+            background=surface,
+            foreground=text,
+            font=("Segoe UI", 20, "bold"),
+        )
+        style.configure(
+            "DetailSubtitle.TLabel",
+            background=surface,
+            foreground=subtle,
+            font=("Segoe UI", 12),
+        )
+        style.configure(
+            "DetailText.TLabel",
+            background=surface,
+            foreground=text,
+            font=("Segoe UI", 11),
+            wraplength=440,
+            justify="left",
+        )
+        style.configure(
+            "Primary.TButton",
             background=accent,
             foreground=background,
             font=("Segoe UI", 11, "bold"),
             padding=10,
+            borderwidth=0,
         )
         style.map(
-            "Card.TButton",
-            background=[("active", "#0ea5e9"), ("pressed", "#0284c7")],
-            foreground=[("disabled", subtle)],
+            "Primary.TButton",
+            background=[("active", palette["accent_active"]), ("pressed", palette["accent_pressed"])],
+            foreground=[("disabled", muted)],
         )
+        style.configure(
+            "Ghost.TButton",
+            background=surface,
+            foreground=accent,
+            borderwidth=0,
+            font=("Segoe UI", 10, "bold"),
+        )
+        style.map("Ghost.TButton", background=[("active", surface)], foreground=[("active", accent)])
+        style.configure(
+            "Pill.TButton",
+            background=accent,
+            foreground=background,
+            font=("Segoe UI", 10, "bold"),
+            padding=(12, 6),
+            borderwidth=0,
+        )
+        style.map(
+            "Pill.TButton",
+            background=[("active", palette["accent_active"]), ("pressed", palette["accent_pressed"])],
+            foreground=[("disabled", muted)],
+        )
+        style.configure(
+            "Neutral.TButton",
+            background=surface,
+            foreground=accent,
+            font=("Segoe UI", 10, "bold"),
+            padding=(12, 6),
+            borderwidth=0,
+        )
+        style.map("Neutral.TButton", background=[("active", surface)], foreground=[("active", accent)])
 
         style.configure(
             "Treeview",
             background=surface,
             fieldbackground=surface,
             foreground=text,
-            rowheight=28,
+            rowheight=30,
             font=("Segoe UI", 11),
+            borderwidth=0,
         )
         style.configure(
-            "Treeview.Heading", background=surface, foreground=subtle, font=("Segoe UI", 11, "bold")
+            "Treeview.Heading",
+            background=surface,
+            foreground=subtle,
+            font=("Segoe UI", 11, "bold"),
         )
         style.map("Treeview", background=[("selected", accent)], foreground=[("selected", background)])
         style.map("Treeview.Heading", relief=[("active", "flat"), ("pressed", "flat")])
+
+        style.configure(
+            "Asset.TFrame",
+            background=surface,
+            relief="flat",
+            padding=16,
+        )
+        style.configure(
+            "AssetTitle.TLabel",
+            background=surface,
+            foreground=text,
+            font=("Segoe UI", 12, "bold"),
+        )
+        style.configure(
+            "AssetStatus.TLabel",
+            background=surface,
+            foreground=subtle,
+            font=("Segoe UI", 10),
+        )
 
     def _build_header(self, container: ttk.Frame) -> None:
         header = ttk.Frame(container, style="Stats.TFrame")
@@ -133,11 +256,28 @@ class DesktopUI:
             style="CardValue.TLabel",
         ).pack(side=tk.LEFT)
 
+        button_bar = ttk.Frame(header, style="Stats.TFrame")
+        button_bar.pack(side=tk.RIGHT)
+
         ttk.Button(
-            header,
+            button_bar,
             text="Add lecture",
             command=self._open_add_dialog,
-            style="Card.TButton",
+            style="Primary.TButton",
+        ).pack(side=tk.RIGHT, padx=(12, 0))
+
+        ttk.Button(
+            button_bar,
+            text="Settings",
+            command=self._open_settings_dialog,
+            style="Ghost.TButton",
+        ).pack(side=tk.RIGHT, padx=(12, 0))
+
+        ttk.Button(
+            button_bar,
+            textvariable=self._theme_button_text,
+            command=self._toggle_theme,
+            style="Ghost.TButton",
         ).pack(side=tk.RIGHT)
 
     def _build_stats(self, container: ttk.Frame, snapshot: OverviewSnapshot) -> None:
@@ -152,21 +292,22 @@ class DesktopUI:
         ]
 
         for index, (label, value) in enumerate(metrics):
-            card = ttk.Frame(stats_frame, padding=18, style="Card.TFrame")
+            card = ttk.Frame(stats_frame, style="Card.TFrame")
             card.grid(row=0, column=index, sticky="nsew", padx=(0, 18 if index < len(metrics) - 1 else 0))
             ttk.Label(card, text=label, style="CardTitle.TLabel").pack(anchor="w")
             value_var = tk.StringVar(value=str(value))
             self._stat_vars[label] = value_var
             ttk.Label(card, textvariable=value_var, style="CardValue.TLabel").pack(anchor="w", pady=(8, 0))
 
-        asset_card = ttk.Frame(stats_frame, padding=18, style="Card.TFrame")
+        asset_card = ttk.Frame(stats_frame, style="Card.TFrame")
         asset_card.grid(row=0, column=len(metrics), sticky="nsew")
         ttk.Label(asset_card, text="Assets", style="CardTitle.TLabel").pack(anchor="w")
         asset_texts = [
             f"{ASSET_LABELS[key]}: {snapshot.asset_totals.get(key, 0)}"
             for key in ("audio", "slides", "transcript", "slide_images")
         ]
-        self._asset_text_var = tk.StringVar(value="\n".join(asset_texts))
+        self._asset_text_var = tk.StringVar(value="
+".join(asset_texts))
         ttk.Label(
             asset_card,
             textvariable=self._asset_text_var,
@@ -202,7 +343,7 @@ class DesktopUI:
         )
 
         self._asset_container = ttk.Frame(detail_panel, style="PanelBody.TFrame")
-        self._asset_container.pack(anchor="w", fill=tk.X, pady=(16, 0))
+        self._asset_container.pack(anchor="w", fill=tk.BOTH, expand=True, pady=(16, 0))
 
         if snapshot.class_count == 0:
             self._show_empty_state()
@@ -219,37 +360,60 @@ class DesktopUI:
     # ------------------------------------------------------------------
     # Tree population and selection
     # ------------------------------------------------------------------
-    def _populate_tree(self, tree: ttk.Treeview, snapshot: OverviewSnapshot) -> None:
+    def _populate_tree(
+        self,
+        tree: ttk.Treeview,
+        snapshot: OverviewSnapshot,
+        *,
+        preferred_selection: Optional[str] = None,
+    ) -> None:
         tree.delete(*tree.get_children())
         self._tree_items.clear()
 
         for class_overview in snapshot.classes:
-            class_id = tree.insert("", "end", text=class_overview.record.name, open=True)
-            self._tree_items[class_id] = ("class", class_overview)
+            class_id = f"class:{class_overview.record.id}"
+            tree.insert("", "end", iid=class_id, text=class_overview.record.name, open=True)
+            self._tree_items[class_id] = ("class", class_overview, None, class_overview)
 
             if not class_overview.modules:
-                empty_id = tree.insert(class_id, "end", text="No modules yet")
-                self._tree_items[empty_id] = ("empty", None)
-                tree.item(empty_id, open=False)
+                empty_id = f"empty:class:{class_overview.record.id}"
+                tree.insert(class_id, "end", iid=empty_id, text="No modules yet")
+                self._tree_items[empty_id] = ("empty", None, None, None)
                 continue
 
             for module_overview in class_overview.modules:
-                module_id = tree.insert(class_id, "end", text=module_overview.record.name, open=False)
-                self._tree_items[module_id] = ("module", module_overview)
+                module_id = f"module:{module_overview.record.id}"
+                tree.insert(class_id, "end", iid=module_id, text=module_overview.record.name, open=False)
+                self._tree_items[module_id] = ("module", module_overview, module_overview, class_overview)
 
                 if not module_overview.lectures:
-                    empty_id = tree.insert(module_id, "end", text="No lectures yet")
-                    self._tree_items[empty_id] = ("empty", None)
+                    empty_id = f"empty:module:{module_overview.record.id}"
+                    tree.insert(module_id, "end", iid=empty_id, text="No lectures yet")
+                    self._tree_items[empty_id] = ("empty", None, None, None)
                     continue
 
                 for lecture_overview in module_overview.lectures:
-                    lecture_id = tree.insert(module_id, "end", text=lecture_overview.record.name, open=False)
-                    self._tree_items[lecture_id] = ("lecture", lecture_overview)
+                    lecture_id = f"lecture:{lecture_overview.record.id}"
+                    tree.insert(module_id, "end", iid=lecture_id, text=lecture_overview.record.name, open=False)
+                    self._tree_items[lecture_id] = (
+                        "lecture",
+                        lecture_overview,
+                        module_overview,
+                        class_overview,
+                    )
 
-        first_item = tree.get_children()
-        if first_item:
-            tree.selection_set(first_item[0])
-            tree.focus(first_item[0])
+        target = preferred_selection
+        if target and target not in self._tree_items:
+            target = None
+
+        if target is None:
+            children = tree.get_children()
+            if children:
+                target = children[0]
+
+        if target:
+            tree.selection_set(target)
+            tree.focus(target)
             self._on_tree_select()
         else:
             self._show_empty_state()
@@ -263,16 +427,27 @@ class DesktopUI:
             return
 
         item_id = selection[0]
-        kind, payload = self._tree_items.get(item_id, ("empty", None))
+        kind, payload, module_overview, class_overview = self._tree_items.get(
+            item_id, ("empty", None, None, None)
+        )
 
         title_var, subtitle_var, description_var = self._require_detail_vars()
 
-        if kind == "class":
+        if kind == "class" and isinstance(payload, ClassOverview):
+            self._active_class = payload
+            self._active_module = None
+            self._selected_lecture_id = None
             self._show_class_details(payload)
-        elif kind == "module":
+        elif kind == "module" and isinstance(payload, ModuleOverview):
+            self._active_class = class_overview
+            self._active_module = payload
+            self._selected_lecture_id = None
             self._show_module_details(payload)
-        elif kind == "lecture":
-            self._show_lecture_details(payload)
+        elif kind == "lecture" and isinstance(payload, LectureOverview):
+            self._active_class = class_overview
+            self._active_module = module_overview
+            self._selected_lecture_id = payload.record.id
+            self._show_lecture_details(payload, module_overview, class_overview)
         else:
             title_var.set("Nothing to show")
             subtitle_var.set("")
@@ -308,19 +483,25 @@ class DesktopUI:
         description_var.set(overview.record.description or "No description provided yet.")
         self._render_assets([])
 
-    def _show_lecture_details(self, overview: LectureOverview) -> None:
+    def _show_lecture_details(
+        self,
+        overview: LectureOverview,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
         title_var, subtitle_var, description_var = self._require_detail_vars()
         title_var.set(overview.record.name)
         subtitle_var.set("Lecture")
         description_var.set(overview.record.description or "No description provided yet.")
-        self._render_assets(overview.assets)
+
+        self._render_asset_panel(overview, module_overview, class_overview)
 
     def _require_detail_vars(self) -> tuple[tk.StringVar, tk.StringVar, tk.StringVar]:
         if self._title_var is None or self._subtitle_var is None or self._description_var is None:
             raise RuntimeError("Detail variables must be initialized before use.")
         return self._title_var, self._subtitle_var, self._description_var
 
-    def _render_assets(self, assets: list[str]) -> None:
+    def _render_assets(self, assets: List[str]) -> None:
         if not self._asset_container:
             return
 
@@ -344,6 +525,105 @@ class DesktopUI:
                 style="DetailText.TLabel",
             )
             bubble.pack(anchor="w", pady=4)
+
+    def _render_asset_panel(
+        self,
+        overview: LectureOverview,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        if not self._asset_container:
+            return
+
+        for child in self._asset_container.winfo_children():
+            child.destroy()
+
+        ttk.Label(self._asset_container, text="Lecture assets", style="PanelHeading.TLabel").pack(anchor="w")
+
+        record = overview.record
+        audio_status = self._describe_asset(record.audio_path)
+        slide_status = self._describe_asset(record.slide_path)
+        transcript_status = self._describe_asset(record.transcript_path)
+        image_status = self._describe_image_asset(record.slide_image_dir)
+
+        ttk.Frame(self._asset_container, height=8, style="PanelBody.TFrame").pack(fill=tk.X)
+
+        self._create_asset_card(
+            "🎧 Audio",
+            audio_status,
+            [
+                ("Upload audio", lambda: self._upload_audio(record, module_overview, class_overview), "Pill.TButton"),
+                ("Transcribe", lambda: self._transcribe_audio(record, module_overview, class_overview), "Neutral.TButton"),
+                ("Open file", lambda: self._open_asset_path(record.audio_path), "Neutral.TButton"),
+            ],
+        )
+
+        self._create_asset_card(
+            "📑 Slides",
+            slide_status,
+            [
+                ("Upload PDF", lambda: self._upload_slides(record, module_overview, class_overview), "Pill.TButton"),
+                ("Render images", lambda: self._render_slide_images(record, module_overview, class_overview), "Neutral.TButton"),
+                ("Open file", lambda: self._open_asset_path(record.slide_path), "Neutral.TButton"),
+            ],
+        )
+
+        self._create_asset_card(
+            "📝 Transcript",
+            transcript_status,
+            [
+                ("Upload transcript", lambda: self._upload_transcript(record, module_overview, class_overview), "Pill.TButton"),
+                ("Open file", lambda: self._open_asset_path(record.transcript_path), "Neutral.TButton"),
+            ],
+        )
+
+        self._create_asset_card(
+            "🖼️ Slide images",
+            image_status,
+            [
+                ("Upload images", lambda: self._upload_slide_images(record, module_overview, class_overview), "Pill.TButton"),
+                ("Open folder", lambda: self._open_asset_path(record.slide_image_dir, directory=True), "Neutral.TButton"),
+            ],
+        )
+
+    def _create_asset_card(
+        self,
+        title: str,
+        status: str,
+        actions: List[Tuple[str, Callable[[], None], str]],
+    ) -> None:
+        if not self._asset_container:
+            return
+
+        card = ttk.Frame(self._asset_container, style="Asset.TFrame")
+        card.pack(fill=tk.X, expand=False, pady=(8, 0))
+
+        ttk.Label(card, text=title, style="AssetTitle.TLabel").pack(anchor="w")
+        ttk.Label(card, text=status, style="AssetStatus.TLabel").pack(anchor="w", pady=(2, 10))
+
+        action_bar = ttk.Frame(card, style="PanelBody.TFrame")
+        action_bar.pack(anchor="w")
+
+        for index, (label, command, style_name) in enumerate(actions):
+            ttk.Button(action_bar, text=label, command=command, style=style_name).pack(
+                side=tk.LEFT, padx=(0, 10 if index < len(actions) - 1 else 0)
+            )
+
+    def _describe_asset(self, path: Optional[str]) -> str:
+        if not path:
+            return "No file linked yet."
+        return f"Linked: {Path(path).name}"
+
+    def _describe_image_asset(self, directory: Optional[str]) -> str:
+        if not directory:
+            return "No images generated yet."
+        if not self._config:
+            return f"Images stored at {directory}"
+        absolute = self._config.storage_root / directory
+        count = 0
+        if absolute.exists():
+            count = sum(1 for item in absolute.iterdir() if item.is_file())
+        return f"{count} images available in {absolute.name}"
 
     # ------------------------------------------------------------------
     # Creation workflow
@@ -415,8 +695,10 @@ class DesktopUI:
             )
             self._refresh_ui()
 
-        ttk.Button(button_bar, text="Cancel", command=close_dialog).pack(side=tk.RIGHT, padx=(12, 0))
-        ttk.Button(button_bar, text="Add", command=submit).pack(side=tk.RIGHT)
+        ttk.Button(button_bar, text="Cancel", command=close_dialog, style="Ghost.TButton").pack(
+            side=tk.RIGHT, padx=(12, 0)
+        )
+        ttk.Button(button_bar, text="Add", command=submit, style="Primary.TButton").pack(side=tk.RIGHT)
 
         dialog.wait_window()
 
@@ -445,6 +727,494 @@ class DesktopUI:
 
         self._repository.add_lecture(module_id, lecture_title, description)
 
+    # ------------------------------------------------------------------
+    # Asset management helpers
+    # ------------------------------------------------------------------
+    def _upload_audio(
+        self,
+        record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        file_path = filedialog.askopenfilename(
+            title="Select audio file",
+            filetypes=[("Audio/Video", "*.mp3 *.wav *.m4a *.mp4 *.mkv"), ("All files", "*.*")],
+        )
+        if not file_path:
+            return
+        self._store_file(record, Path(file_path), "audio_path", module_overview, class_overview)
+
+    def _upload_slides(
+        self,
+        record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        file_path = filedialog.askopenfilename(
+            title="Select PDF slides",
+            filetypes=[("PDF", "*.pdf"), ("All files", "*.*")],
+        )
+        if not file_path:
+            return
+        self._store_file(record, Path(file_path), "slide_path", module_overview, class_overview)
+
+    def _upload_transcript(
+        self,
+        record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        file_path = filedialog.askopenfilename(
+            title="Select transcript",
+            filetypes=[("Text", "*.txt *.md"), ("All files", "*.*")],
+        )
+        if not file_path:
+            return
+        self._store_file(
+            record,
+            Path(file_path),
+            "transcript_path",
+            module_overview,
+            class_overview,
+            destination="transcript",
+        )
+
+    def _upload_slide_images(
+        self,
+        record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        files = filedialog.askopenfilenames(
+            title="Select slide images",
+            filetypes=[
+                ("Images", "*.png *.jpg *.jpeg *.webp *.bmp *.gif"),
+                ("All files", "*.*"),
+            ],
+        )
+        if not files:
+            return
+        self._store_images(record, [Path(path) for path in files], module_overview, class_overview)
+
+    def _store_file(
+        self,
+        lecture_record: LectureRecord,
+        source: Path,
+        attribute: str,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+        *,
+        destination: str = "raw",
+    ) -> None:
+        if not self._config:
+            messagebox.showerror(
+                "Storage unavailable",
+                "Asset storage is not configured.",
+                parent=self._root,
+            )
+            return
+
+        hierarchy = self._resolve_hierarchy(lecture_record, module_overview, class_overview)
+        if hierarchy is None:
+            return
+        class_record, module_record = hierarchy
+
+        lecture_paths = LecturePaths.build(
+            self._config.storage_root, class_record.name, module_record.name, lecture_record.name
+        )
+        lecture_paths.ensure()
+
+        destination_dir = {
+            "raw": lecture_paths.raw_dir,
+            "transcript": lecture_paths.transcript_dir,
+            "slides": lecture_paths.slide_dir,
+        }.get(destination, lecture_paths.raw_dir)
+
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        target = destination_dir / source.name
+        shutil.copy2(source, target)
+
+        relative = target.relative_to(self._config.storage_root).as_posix()
+        self._repository.update_lecture_assets(lecture_record.id, **{attribute: relative})
+        self._refresh_ui()
+
+    def _store_images(
+        self,
+        lecture_record: LectureRecord,
+        sources: List[Path],
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        if not self._config:
+            messagebox.showerror(
+                "Storage unavailable",
+                "Asset storage is not configured.",
+                parent=self._root,
+            )
+            return
+
+        hierarchy = self._resolve_hierarchy(lecture_record, module_overview, class_overview)
+        if hierarchy is None:
+            return
+        class_record, module_record = hierarchy
+
+        lecture_paths = LecturePaths.build(
+            self._config.storage_root, class_record.name, module_record.name, lecture_record.name
+        )
+        lecture_paths.ensure()
+
+        timestamp = datetime.now().strftime("images-%Y%m%d-%H%M%S")
+        destination_dir = lecture_paths.slide_dir / timestamp
+        destination_dir.mkdir(parents=True, exist_ok=True)
+
+        for source in sources:
+            target = destination_dir / source.name
+            shutil.copy2(source, target)
+
+        relative = destination_dir.relative_to(self._config.storage_root).as_posix()
+        self._repository.update_lecture_assets(lecture_record.id, slide_image_dir=relative)
+        self._refresh_ui()
+
+    def _transcribe_audio(
+        self,
+        lecture_record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        if not self._config:
+            messagebox.showerror(
+                "Transcription unavailable",
+                "Asset storage is not configured.",
+                parent=self._root,
+            )
+            return
+
+        if not lecture_record.audio_path:
+            messagebox.showwarning("Transcribe audio", "Upload an audio file before transcribing.", parent=self._root)
+            return
+
+        hierarchy = self._resolve_hierarchy(lecture_record, module_overview, class_overview)
+        if hierarchy is None:
+            return
+        class_record, module_record = hierarchy
+
+        lecture_paths = LecturePaths.build(
+            self._config.storage_root, class_record.name, module_record.name, lecture_record.name
+        )
+        lecture_paths.ensure()
+
+        audio_file = self._config.storage_root / lecture_record.audio_path
+        if not audio_file.exists():
+            messagebox.showerror(
+                "Transcribe audio",
+                f"The audio file could not be found at {audio_file}.",
+                parent=self._root,
+            )
+            return
+
+        try:
+            engine = FasterWhisperTranscription(
+                self._settings.whisper_model,
+                download_root=self._config.assets_root,
+                compute_type=self._settings.whisper_compute_type,
+                beam_size=int(self._settings.whisper_beam_size),
+            )
+        except Exception as error:  # pragma: no cover - depends on optional packages
+            messagebox.showerror(
+                "Transcribe audio",
+                f"Unable to initialise transcription engine:
+{error}",
+                parent=self._root,
+            )
+            return
+
+        try:
+            result = engine.transcribe(audio_file, lecture_paths.transcript_dir)
+        except Exception as error:  # pragma: no cover - depends on optional packages
+            messagebox.showerror(
+                "Transcribe audio",
+                f"Transcription failed:
+{error}",
+                parent=self._root,
+            )
+            return
+
+        relative = result.text_path.relative_to(self._config.storage_root).as_posix()
+        self._repository.update_lecture_assets(lecture_record.id, transcript_path=relative)
+        self._refresh_ui()
+        messagebox.showinfo("Transcribe audio", "Transcript generated successfully.", parent=self._root)
+
+    def _render_slide_images(
+        self,
+        lecture_record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> None:
+        if not self._config:
+            messagebox.showerror(
+                "Render slides",
+                "Asset storage is not configured.",
+                parent=self._root,
+            )
+            return
+
+        if not lecture_record.slide_path:
+            messagebox.showwarning("Render slides", "Upload a PDF slideshow first.", parent=self._root)
+            return
+
+        hierarchy = self._resolve_hierarchy(lecture_record, module_overview, class_overview)
+        if hierarchy is None:
+            return
+        class_record, module_record = hierarchy
+
+        lecture_paths = LecturePaths.build(
+            self._config.storage_root, class_record.name, module_record.name, lecture_record.name
+        )
+        lecture_paths.ensure()
+
+        slide_file = self._config.storage_root / lecture_record.slide_path
+        if not slide_file.exists():
+            messagebox.showerror(
+                "Render slides",
+                f"The slide file could not be found at {slide_file}.",
+                parent=self._root,
+            )
+            return
+
+        try:
+            converter = PyMuPDFSlideConverter(dpi=int(self._settings.slide_dpi))
+        except Exception as error:  # pragma: no cover - optional dependency
+            messagebox.showerror(
+                "Render slides",
+                f"Unable to initialise slide converter:
+{error}",
+                parent=self._root,
+            )
+            return
+
+        try:
+            generated = list(converter.convert(slide_file, lecture_paths.slide_dir))
+        except Exception as error:  # pragma: no cover - optional dependency
+            messagebox.showerror(
+                "Render slides",
+                f"Slide conversion failed:
+{error}",
+                parent=self._root,
+            )
+            return
+
+        if not generated:
+            messagebox.showwarning("Render slides", "No images were generated from the slideshow.", parent=self._root)
+            return
+
+        relative = lecture_paths.slide_dir.relative_to(self._config.storage_root).as_posix()
+        self._repository.update_lecture_assets(lecture_record.id, slide_image_dir=relative)
+        self._refresh_ui()
+        messagebox.showinfo("Render slides", "Slide images generated successfully.", parent=self._root)
+
+    def _resolve_hierarchy(
+        self,
+        lecture_record: LectureRecord,
+        module_overview: ModuleOverview | None,
+        class_overview: ClassOverview | None,
+    ) -> Optional[Tuple[ClassRecord, ModuleRecord]]:
+        module_record = (
+            module_overview.record if module_overview else self._repository.get_module(lecture_record.module_id)
+        )
+        if module_record is None:
+            messagebox.showerror("Asset handling", "Module information is unavailable.", parent=self._root)
+            return None
+
+        class_record = class_overview.record if class_overview else self._repository.get_class(module_record.class_id)
+        if class_record is None:
+            messagebox.showerror("Asset handling", "Class information is unavailable.", parent=self._root)
+            return None
+
+        return class_record, module_record
+
+    def _open_asset_path(self, relative: Optional[str], directory: bool = False) -> None:
+        if not relative:
+            messagebox.showinfo("Open asset", "No asset available yet.", parent=self._root)
+            return
+
+        if not self._config:
+            messagebox.showerror("Open asset", "Asset storage is not configured.", parent=self._root)
+            return
+
+        path = self._config.storage_root / relative
+        if not path.exists():
+            messagebox.showerror("Open asset", f"Path not found: {path}", parent=self._root)
+            return
+
+        target = path if directory or path.is_dir() else path
+
+        try:
+            if platform.system() == "Windows":
+                os.startfile(target)  # type: ignore[attr-defined]
+            elif platform.system() == "Darwin":
+                subprocess.check_call(["open", str(target)])
+            else:
+                subprocess.check_call(["xdg-open", str(target)])
+        except Exception as error:
+            messagebox.showerror("Open asset", f"Failed to open asset:
+{error}", parent=self._root)
+
+    # ------------------------------------------------------------------
+    # Settings and theming
+    # ------------------------------------------------------------------
+    def _toggle_theme(self) -> None:
+        self._current_theme = "light" if self._current_theme == "dark" else "dark"
+        self._settings.theme = self._current_theme
+        if self._settings_store:
+            self._settings_store.save(self._settings)
+        self._apply_theme()
+
+    def _apply_theme(self) -> None:
+        if not self._root:
+            return
+
+        style = ttk.Style(self._root)
+        palette = self._get_palette(self._current_theme)
+        self._configure_styles(style, palette)
+        self._root.configure(background=palette["background"])
+        self._update_theme_button()
+
+    def _update_theme_button(self) -> None:
+        if self._theme_button_text is None:
+            return
+        if self._current_theme == "dark":
+            self._theme_button_text.set("Switch to light mode")
+        else:
+            self._theme_button_text.set("Switch to dark mode")
+
+    def _get_palette(self, theme: ThemeName) -> Palette:
+        if theme == "light":
+            return {
+                "background": "#f1f5f9",
+                "surface": "#ffffff",
+                "accent": "#2563eb",
+                "accent_active": "#1d4ed8",
+                "accent_pressed": "#1e40af",
+                "subtle": "#475569",
+                "text": "#0f172a",
+                "muted": "#94a3b8",
+            }
+        return {
+            "background": "#0f172a",
+            "surface": "#1f2937",
+            "accent": "#38bdf8",
+            "accent_active": "#0ea5e9",
+            "accent_pressed": "#0284c7",
+            "subtle": "#94a3b8",
+            "text": "#f8fafc",
+            "muted": "#64748b",
+        }
+
+    def _open_settings_dialog(self) -> None:
+        if not self._root:
+            return
+
+        dialog = tk.Toplevel(self._root)
+        dialog.title("Settings")
+        dialog.transient(self._root)
+        dialog.grab_set()
+        dialog.resizable(False, False)
+
+        frame = ttk.Frame(dialog, padding=20, style="Panel.TFrame")
+        frame.grid(row=0, column=0, sticky="nsew")
+
+        theme_var = tk.StringVar(value=self._current_theme)
+        whisper_model_var = tk.StringVar(value=self._settings.whisper_model)
+        compute_type_var = tk.StringVar(value=self._settings.whisper_compute_type)
+        beam_size_var = tk.IntVar(value=int(self._settings.whisper_beam_size))
+        slide_dpi_var = tk.IntVar(value=int(self._settings.slide_dpi))
+
+        ttk.Label(frame, text="Appearance", style="DetailTitle.TLabel").grid(row=0, column=0, sticky="w")
+
+        theme_frame = ttk.Frame(frame, style="PanelBody.TFrame")
+        theme_frame.grid(row=1, column=0, sticky="w", pady=(4, 16))
+        ttk.Radiobutton(theme_frame, text="Dark", value="dark", variable=theme_var).pack(side=tk.LEFT)
+        ttk.Radiobutton(theme_frame, text="Light", value="light", variable=theme_var).pack(side=tk.LEFT, padx=(12, 0))
+
+        ttk.Label(frame, text="Whisper settings", style="DetailTitle.TLabel").grid(
+            row=2, column=0, sticky="w"
+        )
+
+        whisper_frame = ttk.Frame(frame, style="PanelBody.TFrame")
+        whisper_frame.grid(row=3, column=0, sticky="w", pady=(4, 16))
+
+        ttk.Label(whisper_frame, text="Model", style="CardTitle.TLabel").grid(row=0, column=0, sticky="w")
+        ttk.Entry(whisper_frame, textvariable=whisper_model_var, width=18).grid(
+            row=0,
+            column=1,
+            sticky="w",
+            padx=(12, 0),
+        )
+
+        ttk.Label(whisper_frame, text="Compute type", style="CardTitle.TLabel").grid(
+            row=1, column=0, sticky="w", pady=(6, 0)
+        )
+        ttk.Entry(whisper_frame, textvariable=compute_type_var, width=18).grid(
+            row=1,
+            column=1,
+            sticky="w",
+            padx=(12, 0),
+            pady=(6, 0),
+        )
+
+        ttk.Label(whisper_frame, text="Beam size", style="CardTitle.TLabel").grid(
+            row=2, column=0, sticky="w", pady=(6, 0)
+        )
+        ttk.Spinbox(whisper_frame, from_=1, to=10, textvariable=beam_size_var, width=6).grid(
+            row=2,
+            column=1,
+            sticky="w",
+            padx=(12, 0),
+            pady=(6, 0),
+        )
+
+        ttk.Label(frame, text="Slide rendering", style="DetailTitle.TLabel").grid(
+            row=4, column=0, sticky="w"
+        )
+        slide_frame = ttk.Frame(frame, style="PanelBody.TFrame")
+        slide_frame.grid(row=5, column=0, sticky="w", pady=(4, 12))
+        ttk.Label(slide_frame, text="DPI", style="CardTitle.TLabel").grid(row=0, column=0, sticky="w")
+        ttk.Spinbox(slide_frame, from_=72, to=600, increment=10, textvariable=slide_dpi_var, width=6).grid(
+            row=0,
+            column=1,
+            sticky="w",
+            padx=(12, 0),
+        )
+
+        button_bar = ttk.Frame(frame, style="Stats.TFrame")
+        button_bar.grid(row=6, column=0, sticky="e", pady=(12, 0))
+
+        def close_dialog() -> None:
+            dialog.grab_release()
+            dialog.destroy()
+
+        def save_settings() -> None:
+            self._current_theme = theme_var.get()  # type: ignore[assignment]
+            self._settings.theme = self._current_theme
+            self._settings.whisper_model = whisper_model_var.get().strip() or "base"
+            self._settings.whisper_compute_type = compute_type_var.get().strip() or "int8"
+            self._settings.whisper_beam_size = max(1, beam_size_var.get())
+            self._settings.slide_dpi = max(72, slide_dpi_var.get())
+            if self._settings_store:
+                self._settings_store.save(self._settings)
+            self._apply_theme()
+            close_dialog()
+
+        ttk.Button(button_bar, text="Cancel", command=close_dialog, style="Ghost.TButton").pack(
+            side=tk.RIGHT, padx=(12, 0)
+        )
+        ttk.Button(button_bar, text="Save", command=save_settings, style="Primary.TButton").pack(side=tk.RIGHT)
+
+        dialog.wait_window()
+
+    # ------------------------------------------------------------------
+    # Refresh helpers
+    # ------------------------------------------------------------------
     def _refresh_ui(self) -> None:
         if not self._root or not self._tree:
             return
@@ -466,9 +1236,30 @@ class DesktopUI:
                 f"{ASSET_LABELS[key]}: {snapshot.asset_totals.get(key, 0)}"
                 for key in ("audio", "slides", "transcript", "slide_images")
             ]
-            self._asset_text_var.set("\n".join(asset_texts))
+            self._asset_text_var.set("
+".join(asset_texts))
 
-        self._populate_tree(self._tree, snapshot)
+        preferred = None
+        if self._selected_lecture_id is not None:
+            preferred = f"lecture:{self._selected_lecture_id}"
+        elif self._tree.selection():
+            preferred = self._tree.selection()[0]
+
+        self._populate_tree(self._tree, snapshot, preferred_selection=preferred)
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+    def _get_selected_overview(self) -> Optional[LectureOverview]:
+        if not self._tree:
+            return None
+        selection = self._tree.selection()
+        if not selection:
+            return None
+        kind, payload, _module, _class = self._tree_items.get(selection[0], ("", None, None, None))
+        if kind == "lecture" and isinstance(payload, LectureOverview):
+            return payload
+        return None
 
 
 __all__ = ["DesktopUI"]

--- a/run.py
+++ b/run.py
@@ -64,7 +64,7 @@ def overview(style: UIStyle = style_option) -> None:
 
     repository = LectureRepository(config)
     if style is UIStyle.DESKTOP:
-        ui = DesktopUI(repository)
+        ui = DesktopUI(repository, config=config)
     elif style is UIStyle.MODERN:
         ui = ModernUI(repository)
     else:


### PR DESCRIPTION
## Summary
- add a persisted settings store for UI preferences such as theme and processing defaults
- refresh the desktop UI with light/dark palettes, a settings dialog, and asset cards that support uploads, processing, and quick access
- pass application configuration into the desktop UI so storage-aware actions can succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda265935083308bf12e68a5341f29