### PR TITLE
Fix asset stats string construction

### DIFF
--- a/app/ui/desktop.py
+++ b/app/ui/desktop.py
@@ -306,8 +306,7 @@ class DesktopUI:
             f"{ASSET_LABELS[key]}: {snapshot.asset_totals.get(key, 0)}"
             for key in ("audio", "slides", "transcript", "slide_images")
         ]
-        self._asset_text_var = tk.StringVar(value="
-".join(asset_texts))
+        self._asset_text_var = tk.StringVar(value="\n".join(asset_texts))
         ttk.Label(
             asset_card,
             textvariable=self._asset_text_var,


### PR DESCRIPTION
## Summary
- correct the asset statistics string assembly to use a newline separator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda554bd9c8330b3e1e0cd8ccfec80