### PR TITLE
Add python-multipart dependency for FastAPI uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ dependencies = [
     "fastapi>=0.111",
     "uvicorn[standard]>=0.29",
     "jinja2>=3.1",
+    "python-multipart>=0.0.9",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ rich>=13.7
 fastapi>=0.111
 uvicorn[standard]>=0.29
 jinja2>=3.1
+python-multipart>=0.0.9


### PR DESCRIPTION
## Summary
- add python-multipart to the core project dependencies so FastAPI can handle form uploads
- mirror the multipart package in the development requirements file for consistent installs

## Testing
- pip install -r requirements-dev.txt
- python run.py

------
https://chatgpt.com/codex/tasks/task_e_68cdd996aca8833089e525bd09bf7fd4