### PR TITLE
Respect stored Whisper settings during transcription

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -589,10 +589,17 @@ def create_app(repository: LectureRepository, *, config: AppConfig) -> FastAPI:
         )
         lecture_paths.ensure()
 
+        settings = _load_ui_settings()
+        default_settings = UISettings()
+        compute_type = settings.whisper_compute_type or default_settings.whisper_compute_type
+        beam_size = settings.whisper_beam_size or default_settings.whisper_beam_size
+
         try:
             engine = FasterWhisperTranscription(
                 payload.model,
                 download_root=config.assets_root,
+                compute_type=compute_type,
+                beam_size=beam_size,
             )
             result = engine.transcribe(audio_file, lecture_paths.transcript_dir)
         except Exception as error:  # noqa: BLE001 - backend may raise arbitrary errors


### PR DESCRIPTION
## Summary
- load persisted Whisper compute type and beam size values before creating the transcription engine
- pass the stored values (with safe defaults) to FasterWhisperTranscription
- extend the FastAPI transcription test to verify the engine receives the persisted settings

## Testing
- PYTHONPATH=/tmp/stub:$PYTHONPATH pytest tests/test_web_api.py::test_transcribe_audio_uses_backend


------
https://chatgpt.com/codex/tasks/task_e_68ce047f1dc0833096ef85fe1bb88300