### PR TITLE
Add GPU Whisper integration and progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,17 @@ GPU-enabled Whisper transcription. To enable it:
    [ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin)
    and place the file inside `assets/models/`.
 3. When running `python run.py ingest`, set `--whisper-model GPU`.
+4. In the web interface, open **Settings → Whisper transcription** and click
+   **Test support**. If the CLI prints diagnostic output the GPU option is
+   unlocked in both the default model selector and the lecture transcription
+   dropdown.
 
-During ingestion the application probes whether `cli/main.exe` can run on the
-current platform. If it produces output, the GPU path is used and real-time
-progress is displayed using a `====>` bar derived from the CLI timestamps. When
-the binary is unavailable or unsupported, the workflow automatically falls back
-to the standard CPU-based `faster-whisper` pipeline.
+During ingestion or web-driven transcription the application probes whether
+`cli/main.exe` can run on the current platform. If it produces output, the GPU
+path is used and real-time progress is displayed using a `====>` bar derived
+from the CLI timestamps (the web UI mirrors this progress in the status banner).
+When the binary is unavailable or unsupported, the workflow automatically falls
+back to the standard CPU-based `faster-whisper` pipeline.
 
 ## Running Tests
 

--- a/app/processing/__init__.py
+++ b/app/processing/__init__.py
@@ -1,12 +1,22 @@
 """Processing backends for lecture ingestion."""
 
-from .audio import FasterWhisperTranscription
+from .audio import (
+    FasterWhisperTranscription,
+    GPUWhisperError,
+    GPUWhisperModelMissingError,
+    GPUWhisperUnsupportedError,
+    check_gpu_whisper_availability,
+)
 from .recording import AudioRecorder, preprocess_audio, save_preprocessed_wav
 from .slides import PyMuPDFSlideConverter
 
 __all__ = [
     "AudioRecorder",
     "FasterWhisperTranscription",
+    "GPUWhisperError",
+    "GPUWhisperModelMissingError",
+    "GPUWhisperUnsupportedError",
+    "check_gpu_whisper_availability",
     "PyMuPDFSlideConverter",
     "preprocess_audio",
     "save_preprocessed_wav",

--- a/app/processing/audio.py
+++ b/app/processing/audio.py
@@ -10,9 +10,21 @@ import sys
 import wave
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from ..services.ingestion import TranscriptResult, TranscriptionEngine
+
+
+class GPUWhisperError(RuntimeError):
+    """Base class for GPU Whisper related issues."""
+
+
+class GPUWhisperUnsupportedError(GPUWhisperError):
+    """Raised when the GPU CLI is unavailable on the current platform."""
+
+
+class GPUWhisperModelMissingError(GPUWhisperError):
+    """Raised when the expected GPU model binary is not present."""
 
 
 @dataclass
@@ -27,6 +39,80 @@ class TranscriptSegment:
 _SEGMENT_PATTERN = re.compile(
     r"^\[(\d+):(\d+):(\d+\.\d+)\s+-->\s+(\d+):(\d+):(\d+\.\d+)\]\s*(.*)$"
 )
+
+
+def _find_cli_binary() -> Optional[Path]:
+    cli_root = Path(__file__).resolve().parent.parent / "cli"
+    candidates = [cli_root / "main.exe", cli_root / "main"]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _probe_cli(binary: Path) -> Tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            [str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False, ""
+
+    combined = (result.stdout + result.stderr).strip()
+    return bool(combined), combined
+
+
+def _resolve_cli_model_path(download_root: Optional[Path]) -> Path:
+    base_root = download_root if download_root is not None else Path.cwd() / "assets"
+    model_path = base_root / "models" / "ggml-medium.en.bin"
+    if not model_path.exists():
+        raise FileNotFoundError(model_path)
+    return model_path
+
+
+def check_gpu_whisper_availability(download_root: Optional[Path] = None) -> Dict[str, object]:
+    """Return diagnostic information about GPU Whisper availability."""
+
+    binary = _find_cli_binary()
+    if binary is None:
+        return {
+            "supported": False,
+            "message": "GPU Whisper CLI binary not found.",
+            "output": "",
+        }
+
+    supported, output = _probe_cli(binary)
+    if not supported:
+        return {
+            "supported": False,
+            "message": "GPU Whisper CLI produced no output on this platform.",
+            "output": output,
+        }
+
+    try:
+        model_path = _resolve_cli_model_path(download_root)
+    except FileNotFoundError:
+        return {
+            "supported": False,
+            "message": (
+                "GPU Whisper model not found. Download ggml-medium.en.bin and place it inside "
+                "the assets/models directory."
+            ),
+            "output": output,
+        }
+
+    success_message = output.splitlines()[0] if output else "GPU Whisper CLI is available."
+    return {
+        "supported": True,
+        "message": success_message,
+        "output": output,
+        "binary": str(binary),
+        "model": str(model_path),
+    }
 
 
 class FasterWhisperTranscription(TranscriptionEngine):
@@ -48,27 +134,23 @@ class FasterWhisperTranscription(TranscriptionEngine):
 
         requested_model = model_size.lower()
         if requested_model == "gpu":
-            cli_binary = self._resolve_cli_binary()
-            cli_supported = False
-            if cli_binary is not None:
-                cli_supported = self._check_cli_support(cli_binary)
-            if cli_supported:
-                try:
-                    self._cli_model_path = self._resolve_cli_model_path(download_root)
-                except FileNotFoundError as exc:
-                    message = (
-                        "GPU Whisper model not found. Download ggml-medium.en.bin and "
-                        "place it inside the assets/models directory."
-                    )
-                    raise RuntimeError(message) from exc
-                self._use_gpu_cli = True
-                self._cli_binary = cli_binary
-            else:
-                print(
-                    "GPU Whisper CLI is not supported on this platform. Falling back to "
-                    "CPU faster-whisper.",
-                    file=sys.stderr,
+            cli_binary = _find_cli_binary()
+            if cli_binary is None:
+                raise GPUWhisperUnsupportedError("GPU Whisper CLI binary not found.")
+            supported, _output = _probe_cli(cli_binary)
+            if not supported:
+                raise GPUWhisperUnsupportedError(
+                    "GPU Whisper CLI is not supported on this platform."
                 )
+            try:
+                self._cli_model_path = _resolve_cli_model_path(download_root)
+            except FileNotFoundError as exc:
+                raise GPUWhisperModelMissingError(
+                    "GPU Whisper model not found. Download ggml-medium.en.bin and "
+                    "place it inside the assets/models directory."
+                ) from exc
+            self._use_gpu_cli = True
+            self._cli_binary = cli_binary
 
         if not self._use_gpu_cli:
             try:
@@ -77,28 +159,60 @@ class FasterWhisperTranscription(TranscriptionEngine):
                 raise RuntimeError("faster-whisper is not installed") from exc
 
             download_directory = str(download_root) if download_root is not None else None
+            selected_model = model_size if requested_model != "gpu" else "base"
             self._model = WhisperModel(
-                model_size,
+                selected_model,
                 device="cpu",
                 compute_type=compute_type,
                 download_root=download_directory,
             )
 
-    def transcribe(self, audio_path: Path, output_dir: Path) -> TranscriptResult:
+    def transcribe(
+        self,
+        audio_path: Path,
+        output_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[float, Optional[float], str], None]] = None,
+    ) -> TranscriptResult:
         output_dir.mkdir(parents=True, exist_ok=True)
         if self._use_gpu_cli:
-            return self._transcribe_with_cli(audio_path, output_dir)
+            return self._transcribe_with_cli(
+                audio_path, output_dir, progress_callback=progress_callback
+            )
 
         assert self._model is not None  # for type checkers
-        segments, _info = self._model.transcribe(
+        segments, info = self._model.transcribe(
             str(audio_path),
             beam_size=self._beam_size,
         )
 
-        collected_segments = list(self._collect_segments(segments))
-        transcript_text = "\n".join(
-            segment.text.strip() for segment in collected_segments if segment.text.strip()
-        )
+        collected_segments: list[TranscriptSegment] = []
+        transcript_lines: list[str] = []
+        total_duration = float(getattr(info, "duration", 0.0) or 0.0)
+        last_progress = 0.0
+
+        for segment in self._collect_segments(segments):
+            collected_segments.append(segment)
+            cleaned = segment.text.strip()
+            if cleaned:
+                transcript_lines.append(cleaned)
+            last_progress = max(last_progress, segment.end)
+            self._render_progress(
+                segment.end,
+                total_duration if total_duration > 0 else None,
+                progress_callback=progress_callback,
+            )
+
+        if last_progress > 0:
+            self._render_progress(
+                total_duration or last_progress,
+                total_duration if total_duration > 0 else None,
+                progress_callback=progress_callback,
+            )
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+
+        transcript_text = "\n".join(transcript_lines)
 
         transcript_file = output_dir / "transcript.txt"
         transcript_file.write_text(transcript_text, encoding="utf-8")
@@ -112,37 +226,13 @@ class FasterWhisperTranscription(TranscriptionEngine):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _resolve_cli_binary(self) -> Optional[Path]:
-        cli_root = Path(__file__).resolve().parent.parent / "cli"
-        candidates = [cli_root / "main.exe", cli_root / "main"]
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate
-        return None
-
-    def _check_cli_support(self, binary: Path) -> bool:
-        try:
-            result = subprocess.run(
-                [str(binary)],
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            return False
-
-        combined = (result.stdout + result.stderr).strip()
-        return bool(combined)
-
-    def _resolve_cli_model_path(self, download_root: Optional[Path]) -> Path:
-        base_root = download_root if download_root is not None else Path.cwd() / "assets"
-        model_path = base_root / "models" / "ggml-medium.en.bin"
-        if not model_path.exists():
-            raise FileNotFoundError(model_path)
-        return model_path
-
-    def _transcribe_with_cli(self, audio_path: Path, output_dir: Path) -> TranscriptResult:
+    def _transcribe_with_cli(
+        self,
+        audio_path: Path,
+        output_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[float, Optional[float], str], None]] = None,
+    ) -> TranscriptResult:
         assert self._cli_binary is not None
         assert self._cli_model_path is not None
 
@@ -187,7 +277,11 @@ class FasterWhisperTranscription(TranscriptionEngine):
                     if text:
                         transcript_lines.append(text)
                     last_progress = max(last_progress, end)
-                    self._render_progress(last_progress, total_duration)
+                    self._render_progress(
+                        last_progress,
+                        total_duration,
+                        progress_callback=progress_callback,
+                    )
         except Exception:
             process.kill()
             process.wait()
@@ -198,7 +292,11 @@ class FasterWhisperTranscription(TranscriptionEngine):
         return_code = process.wait()
 
         if last_progress > 0:
-            self._render_progress(total_duration or last_progress, total_duration)
+            self._render_progress(
+                total_duration or last_progress,
+                total_duration,
+                progress_callback=progress_callback,
+            )
             sys.stdout.write("\n")
             sys.stdout.flush()
 
@@ -219,7 +317,13 @@ class FasterWhisperTranscription(TranscriptionEngine):
 
         return TranscriptResult(text_path=transcript_file, segments_path=segments_file)
 
-    def _render_progress(self, current: float, total: Optional[float]) -> None:
+    def _render_progress(
+        self,
+        current: float,
+        total: Optional[float],
+        *,
+        progress_callback: Optional[Callable[[float, Optional[float], str], None]] = None,
+    ) -> None:
         if total and total > 0:
             ratio = max(0.0, min(current / total, 1.0))
             width = 30
@@ -231,6 +335,9 @@ class FasterWhisperTranscription(TranscriptionEngine):
             message = f"====> [{bar}] {ratio * 100:5.1f}% ({current:.1f}/{total:.1f}s)"
         else:
             message = f"====> processed {current:.1f}s"
+            ratio = None
+        if progress_callback is not None:
+            progress_callback(current, total, message)
         sys.stdout.write("\r" + message)
         sys.stdout.flush()
 
@@ -268,4 +375,10 @@ class FasterWhisperTranscription(TranscriptionEngine):
             )
 
 
-__all__ = ["FasterWhisperTranscription"]
+__all__ = [
+    "FasterWhisperTranscription",
+    "GPUWhisperError",
+    "GPUWhisperModelMissingError",
+    "GPUWhisperUnsupportedError",
+    "check_gpu_whisper_availability",
+]

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional, Protocol
+from typing import Callable, Iterable, Optional, Protocol
 
 from ..config import AppConfig
 from .naming import build_asset_stem, build_timestamped_name, slugify
@@ -27,7 +27,13 @@ class TranscriptResult:
 class TranscriptionEngine(Protocol):
     """Protocol describing a transcription backend."""
 
-    def transcribe(self, audio_path: Path, output_dir: Path) -> TranscriptResult:
+    def transcribe(
+        self,
+        audio_path: Path,
+        output_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[float, Optional[float], str], None]] = None,
+    ) -> TranscriptResult:
         """Generate a transcript for *audio_path* into *output_dir*."""
 
 

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -781,6 +781,29 @@
         margin-bottom: 0;
       }
 
+      #settings-form .field-inline.gpu-support {
+        flex-direction: row;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .gpu-support-info {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1;
+      }
+
+      #settings-whisper-gpu-status {
+        margin: 0;
+        font-size: 13px;
+        color: var(--muted);
+      }
+
+      #settings-whisper-gpu-test {
+        white-space: nowrap;
+      }
+
       @media (max-width: 960px) {
         main.layout {
           flex-direction: column;
@@ -890,6 +913,7 @@
                     <option value="small">small</option>
                     <option value="medium">medium</option>
                     <option value="large">large</option>
+                    <option value="gpu" class="gpu-only" disabled>GPU (hardware accelerated)</option>
                   </select>
                 </label>
               </div>
@@ -939,6 +963,7 @@
                     <option value="small">Small (accurate)</option>
                     <option value="medium">Medium (detailed)</option>
                     <option value="large">Large (maximum accuracy)</option>
+                    <option value="gpu" class="gpu-only" disabled>GPU (hardware accelerated)</option>
                   </select>
                 </div>
                 <div class="field-inline">
@@ -948,6 +973,15 @@
                 <div class="field-inline">
                   <label for="settings-whisper-beam">Beam size</label>
                   <input id="settings-whisper-beam" type="number" min="1" max="10" required />
+                </div>
+                <div class="field-inline gpu-support">
+                  <div class="gpu-support-info">
+                    <label>GPU support</label>
+                    <p id="settings-whisper-gpu-status">GPU acceleration not tested.</p>
+                  </div>
+                  <button id="settings-whisper-gpu-test" type="button" class="secondary">
+                    Test support
+                  </button>
                 </div>
               </fieldset>
               <fieldset>
@@ -1002,7 +1036,9 @@
           'small',
           'medium',
           'large',
+          'gpu',
         ]);
+        const GPU_MODEL = 'gpu';
         const DEFAULT_WHISPER_MODEL = 'base';
         const SLIDE_DPI_CHOICES = new Set(['150', '200', '300', '400', '600']);
         const DEFAULT_SLIDE_DPI = '200';
@@ -1036,6 +1072,17 @@
           editMode: false,
           activeView: 'details',
           settings: null,
+          gpuWhisper: {
+            supported: false,
+            checked: false,
+            message: 'GPU acceleration not tested.',
+            output: '',
+            lastChecked: null,
+            unavailable: false,
+          },
+          transcriptionProgressTimer: null,
+          transcriptionProgressLectureId: null,
+          lastProgressMessage: '',
         };
 
         const dom = {
@@ -1071,7 +1118,10 @@
           settingsWhisperModel: document.getElementById('settings-whisper-model'),
           settingsWhisperCompute: document.getElementById('settings-whisper-compute'),
           settingsWhisperBeam: document.getElementById('settings-whisper-beam'),
+          settingsWhisperGpuStatus: document.getElementById('settings-whisper-gpu-status'),
+          settingsWhisperGpuTest: document.getElementById('settings-whisper-gpu-test'),
           settingsSlideDpi: document.getElementById('settings-slide-dpi'),
+          gpuModelOptions: Array.from(document.querySelectorAll('option.gpu-only')),
           dialog: {
             root: document.getElementById('dialog-root'),
             backdrop: document.getElementById('dialog-backdrop'),
@@ -1132,11 +1182,84 @@
           dom.status.style.display = 'block';
         }
 
+        function updateGpuWhisperUI(status = {}) {
+          const supported = Boolean(status.supported);
+          const checked = Boolean(status.checked);
+          const unavailable = Boolean(status.unavailable);
+          const output = typeof status.output === 'string' ? status.output : '';
+          const lastChecked = status.last_checked || null;
+          let message =
+            typeof status.message === 'string' && status.message.trim().length > 0
+              ? status.message.trim()
+              : checked
+              ? 'GPU acceleration is unavailable on this platform.'
+              : 'GPU acceleration not tested.';
+
+          state.gpuWhisper = {
+            supported,
+            checked,
+            message,
+            output,
+            lastChecked,
+            unavailable,
+          };
+
+          if (dom.settingsWhisperGpuStatus) {
+            let displayMessage = message;
+            if (output) {
+              const snippet = output.split('\n').slice(0, 5).join('\n').trim();
+              if (snippet && snippet !== message) {
+                displayMessage = `${message}\n${snippet}`;
+              }
+            }
+            dom.settingsWhisperGpuStatus.textContent = displayMessage;
+          }
+
+          if (dom.settingsWhisperGpuTest) {
+            dom.settingsWhisperGpuTest.disabled = unavailable;
+            dom.settingsWhisperGpuTest.textContent = supported ? 'Re-run test' : 'Test support';
+          }
+
+          if (dom.gpuModelOptions) {
+            dom.gpuModelOptions.forEach((option) => {
+              if (option instanceof HTMLOptionElement) {
+                option.disabled = !supported;
+              }
+            });
+          }
+
+          const requestedModel =
+            state.settings?.whisper_model_requested || state.settings?.whisper_model;
+          if (!supported) {
+            if (dom.settingsWhisperModel && dom.settingsWhisperModel.value === GPU_MODEL) {
+              dom.settingsWhisperModel.value = DEFAULT_WHISPER_MODEL;
+            }
+            if (dom.transcribeModel && dom.transcribeModel.value === GPU_MODEL) {
+              dom.transcribeModel.value = DEFAULT_WHISPER_MODEL;
+            }
+            if (state.settings) {
+              state.settings.whisper_model = dom.settingsWhisperModel
+                ? dom.settingsWhisperModel.value
+                : DEFAULT_WHISPER_MODEL;
+            }
+          } else if (requestedModel === GPU_MODEL) {
+            if (dom.settingsWhisperModel) {
+              dom.settingsWhisperModel.value = GPU_MODEL;
+            }
+            if (dom.transcribeModel) {
+              dom.transcribeModel.value = GPU_MODEL;
+            }
+            if (state.settings) {
+              state.settings.whisper_model = GPU_MODEL;
+            }
+          }
+        }
+
         const dialogState = { active: false };
 
         function syncSettingsForm(settings) {
           const themeValue = settings?.theme ?? 'system';
-          const modelValue = normalizeWhisperModel(settings?.whisper_model);
+          const requestedModel = normalizeWhisperModel(settings?.whisper_model);
           const computeRaw = settings?.whisper_compute_type ?? 'int8';
           const computeValue =
             typeof computeRaw === 'string' ? computeRaw.trim() || 'int8' : 'int8';
@@ -1146,22 +1269,29 @@
           );
           const dpiValue = normalizeSlideDpi(settings?.slide_dpi);
 
+          const effectiveModel =
+            requestedModel === GPU_MODEL && !state.gpuWhisper.supported
+              ? DEFAULT_WHISPER_MODEL
+              : requestedModel;
+
           dom.settingsTheme.value = themeValue;
-          dom.settingsWhisperModel.value = modelValue;
+          dom.settingsWhisperModel.value = effectiveModel;
           dom.settingsWhisperCompute.value = computeValue;
           dom.settingsWhisperBeam.value = String(beamNumber);
           dom.settingsSlideDpi.value = dpiValue;
-          dom.transcribeModel.value = modelValue;
+          dom.transcribeModel.value = effectiveModel;
 
           state.settings = {
             theme: themeValue,
-            whisper_model: modelValue,
+            whisper_model: effectiveModel,
+            whisper_model_requested: requestedModel,
             whisper_compute_type: computeValue,
             whisper_beam_size: beamNumber,
             slide_dpi: Number(dpiValue),
           };
 
           applyTheme(themeValue);
+          updateGpuWhisperUI({ ...state.gpuWhisper });
         }
 
         function showDialog({
@@ -1402,6 +1532,77 @@
             return await response.json();
           }
           return null;
+        }
+
+        async function loadGpuWhisperStatus() {
+          try {
+            const payload = await request('/api/settings/whisper-gpu/status');
+            const status = payload?.status || {};
+            updateGpuWhisperUI(status);
+          } catch (error) {
+            updateGpuWhisperUI({
+              supported: false,
+              checked: true,
+              message: error instanceof Error ? error.message : String(error),
+              unavailable: false,
+            });
+          }
+        }
+
+        async function fetchTranscriptionProgress(lectureId) {
+          if (!lectureId) {
+            return null;
+          }
+          try {
+            const payload = await request(
+              `/api/lectures/${lectureId}/transcription-progress`,
+            );
+            return payload?.progress || null;
+          } catch (error) {
+            return null;
+          }
+        }
+
+        function stopTranscriptionProgress({ preserveMessage = false } = {}) {
+          if (state.transcriptionProgressTimer !== null) {
+            window.clearInterval(state.transcriptionProgressTimer);
+          }
+          state.transcriptionProgressTimer = null;
+          state.transcriptionProgressLectureId = null;
+          if (!preserveMessage) {
+            state.lastProgressMessage = '';
+          }
+        }
+
+        function handleProgressUpdate(progress) {
+          if (!progress) {
+            return;
+          }
+          const message = progress.message || '';
+          const variant = progress.error ? 'error' : 'info';
+          if (message && message !== state.lastProgressMessage) {
+            showStatus(message, variant);
+            state.lastProgressMessage = message;
+          }
+          if (progress.finished) {
+            stopTranscriptionProgress({ preserveMessage: true });
+          }
+        }
+
+        function startTranscriptionProgress(lectureId) {
+          stopTranscriptionProgress();
+          if (!lectureId) {
+            return;
+          }
+          state.transcriptionProgressLectureId = lectureId;
+          const poll = async () => {
+            const progress = await fetchTranscriptionProgress(lectureId);
+            if (progress) {
+              handleProgressUpdate(progress);
+            }
+          };
+          poll();
+          state.transcriptionProgressTimer = window.setInterval(poll, 1200);
         }
 
         function clearDetailPanel() {
@@ -2349,22 +2550,108 @@
           if (!state.selectedLectureId) {
             return;
           }
+          const lectureId = state.selectedLectureId;
+          const selectedModel = dom.transcribeModel.value;
           dom.transcribeButton.disabled = true;
+          showStatus('====> Preparing transcription…', 'info');
+          startTranscriptionProgress(lectureId);
           try {
-            await request(`/api/lectures/${state.selectedLectureId}/transcribe`, {
+            const payload = await request(`/api/lectures/${lectureId}/transcribe`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ model: dom.transcribeModel.value }),
+              body: JSON.stringify({ model: selectedModel }),
             });
+            stopTranscriptionProgress();
+            const fallbackModel = payload?.fallback_model;
+            if (fallbackModel) {
+              const fallbackReason =
+                typeof payload?.fallback_reason === 'string'
+                  ? payload.fallback_reason
+                  : 'GPU acceleration is not available on this platform.';
+              await showDialog({
+                title: 'GPU Whisper',
+                message: `${fallbackReason} Falling back to ${fallbackModel} model.`,
+                confirmText: 'OK',
+                cancelText: 'Close',
+                variant: 'danger',
+              });
+              if (dom.transcribeModel) {
+                dom.transcribeModel.value = fallbackModel;
+              }
+              if (dom.settingsWhisperModel) {
+                dom.settingsWhisperModel.value = fallbackModel;
+              }
+              if (state.settings) {
+                state.settings.whisper_model = fallbackModel;
+                state.settings.whisper_model_requested = fallbackModel;
+              }
+              await loadGpuWhisperStatus();
+            } else if (selectedModel === GPU_MODEL) {
+              await loadGpuWhisperStatus();
+            }
             showStatus('Transcription completed.', 'success');
             await refreshData();
-            await selectLecture(state.selectedLectureId);
+            await selectLecture(lectureId);
           } catch (error) {
-            showStatus(error.message, 'error');
+            const message = error instanceof Error ? error.message : String(error);
+            stopTranscriptionProgress();
+            const progress = await fetchTranscriptionProgress(state.selectedLectureId);
+            if (progress && progress.message) {
+              showStatus(progress.message, progress.error ? 'error' : 'info');
+            } else {
+              showStatus(message, 'error');
+            }
           } finally {
             dom.transcribeButton.disabled = false;
           }
         });
+
+        if (dom.settingsWhisperGpuTest) {
+          dom.settingsWhisperGpuTest.addEventListener('click', async () => {
+            if (state.gpuWhisper.unavailable) {
+              return;
+            }
+            dom.settingsWhisperGpuTest.disabled = true;
+            showStatus('====> Checking GPU Whisper support…', 'info');
+            try {
+              const payload = await request('/api/settings/whisper-gpu/test', {
+                method: 'POST',
+              });
+              const status = payload?.status || {};
+              updateGpuWhisperUI(status);
+              if (status.supported) {
+                showStatus('GPU Whisper support confirmed.', 'success');
+                if (state.settings?.whisper_model_requested === GPU_MODEL) {
+                  if (dom.settingsWhisperModel) {
+                    dom.settingsWhisperModel.value = GPU_MODEL;
+                  }
+                  if (dom.transcribeModel) {
+                    dom.transcribeModel.value = GPU_MODEL;
+                  }
+                  state.settings.whisper_model = GPU_MODEL;
+                }
+              } else {
+                const failureMessage =
+                  typeof status.message === 'string' && status.message
+                    ? status.message
+                    : 'GPU Whisper is not supported on this platform.';
+                await showDialog({
+                  title: 'GPU Whisper',
+                  message: failureMessage,
+                  confirmText: 'OK',
+                  cancelText: 'Close',
+                  variant: 'danger',
+                });
+                showStatus(failureMessage, 'error');
+              }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              showStatus(message, 'error');
+            } finally {
+              dom.settingsWhisperGpuTest.disabled = state.gpuWhisper.unavailable;
+            }
+          });
+        }
 
         if (dom.settingsForm) {
           dom.settingsForm.addEventListener('submit', async (event) => {
@@ -2398,6 +2685,9 @@
                 slide_dpi: dpiValue,
               };
               syncSettingsForm(updatedSettings);
+              if (modelValue === GPU_MODEL) {
+                await loadGpuWhisperStatus();
+              }
               showStatus('Settings saved.', 'success');
             } catch (error) {
               showStatus(error.message, 'error');
@@ -2408,8 +2698,9 @@
         updateEditModeUI();
         clearDetailPanel();
         applyTheme('system');
-        loadSettings();
-        refreshData();
+        await loadGpuWhisperStatus();
+        await loadSettings();
+        await refreshData();
       })();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add GPU Whisper detection utilities and progress callbacks to the transcription engine
- expose GPU support controls and transcription progress polling in the FastAPI server and web UI
- document the workflow and extend API tests for GPU status, fallback, and progress endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce352b52948330b00bfe3ac5b85346