### PR TITLE
Run transcription in background thread

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import platform
 import shutil
 import subprocess
@@ -952,7 +953,8 @@ def create_app(repository: LectureRepository, *, config: AppConfig) -> FastAPI:
                 error_reported = True
                 raise HTTPException(status_code=400, detail=str(error)) from error
 
-            result = engine.transcribe(
+            result = await asyncio.to_thread(
+                engine.transcribe,
                 audio_file,
                 lecture_paths.transcript_dir,
                 progress_callback=handle_progress,


### PR DESCRIPTION
## Summary
- run blocking transcription work in a background thread so the event loop can serve progress requests
- import asyncio to support the threaded execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce40e211988330a82b0dd973f8e727