### PR TITLE
Add start.sh bootstrap script for macOS and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,23 @@ Key capabilities include:
 
 1. Ensure Python 3.11 or later is available on your system.
 2. (Optional) Create and activate a virtual environment.
-3. On Windows, run `start.bat` to bootstrap the project. The helper script:
+3. On Windows, run `start.bat` to bootstrap the project. On macOS and Linux,
+   use the companion `start.sh` script. Both helpers:
 
-   - creates a local `.venv` virtual environment if one does not exist,
-   - installs the dependencies from `requirements-dev.txt` (or `requirements.txt`
+   - create a local `.venv` virtual environment if one does not exist,
+   - install the dependencies from `requirements-dev.txt` (or `requirements.txt`
      when the development file is absent), and
-   - launches the CLI so you can pass commands such as `overview` or `ingest`.
+   - launch the CLI so you can pass commands such as `overview` or `ingest`.
 
    ```powershell
    .\start.bat overview
    ```
 
-   On other platforms, install the runtime dependencies manually:
+   ```bash
+   ./start.sh overview
+   ```
+
+   Prefer manual setup? Install the runtime dependencies yourself:
 
    ```bash
    pip install -r requirements-dev.txt

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup() {
+  local exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    echo
+    echo "An error occurred while preparing or running Lecture Tools."
+    echo "Exit code: $exit_code"
+  fi
+}
+trap cleanup EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Error: Could not find '$PYTHON_BIN' on PATH."
+  echo "Please install Python 3.11 or later and try again."
+  exit 1
+fi
+
+if [ ! -d ".venv" ]; then
+  echo "Creating virtual environment..."
+  "$PYTHON_BIN" -m venv .venv
+fi
+
+if [ -x ".venv/bin/python" ]; then
+  VENV_PY=".venv/bin/python"
+elif [ -x ".venv/Scripts/python.exe" ]; then
+  VENV_PY=".venv/Scripts/python.exe"
+else
+  echo "Virtual environment is missing the Python executable."
+  exit 1
+fi
+
+echo "Updating pip..."
+"$VENV_PY" -m pip install --upgrade pip >/dev/null
+
+echo "Installing project requirements..."
+if [ -f "requirements-dev.txt" ]; then
+  "$VENV_PY" -m pip install -r requirements-dev.txt
+elif [ -f "requirements.txt" ]; then
+  "$VENV_PY" -m pip install -r requirements.txt
+else
+  echo "No requirements file found. Skipping dependency installation."
+fi
+
+echo
+if [ "$#" -eq 0 ]; then
+  echo "Launching Lecture Tools CLI..."
+  echo "Hint: pass commands such as 'serve', 'overview' or 'ingest' after start.sh."
+  echo "Example: ./start.sh serve"
+  echo "Example: ./start.sh ingest --help"
+  echo
+fi
+
+"$VENV_PY" "$SCRIPT_DIR/run.py" "$@"


### PR DESCRIPTION
## Summary
- add a cross-platform `start.sh` helper that mirrors the Windows bootstrap flow using Python virtual environments
- document the new script in the README alongside the existing Windows instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceb94ba55c833099e908fbffbdfa36