### PR TITLE
Restore delete button hover animation

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -1064,7 +1064,7 @@
 
       .icon-button.danger:hover,
       .icon-button.danger:focus-visible {
-        background: transparent;
+        background: rgba(220, 38, 38, 0.08);
         color: var(--danger);
       }
 
@@ -1085,7 +1085,7 @@
 
       .icon-button.danger:hover .icon,
       .icon-button.danger:focus-visible .icon {
-        transform: none;
+        transform: rotate(90deg);
       }
 
       .placeholder {


### PR DESCRIPTION
## Summary
- restore the rotate animation for the delete icon button on hover/focus
- add a light red hover/focus background to highlight the delete button state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2e74ea4688330a6250d4645e063b8