### PR TITLE
Fix API base path handling for prefixed deployments

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title data-i18n="document.title">Lecture Tools</title>
+    <script>
+      window.__LECTURE_TOOLS_SERVER_ROOT_PATH__ = "__LECTURE_TOOLS_ROOT_PATH__";
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -3025,7 +3028,31 @@
 
         const DEFAULT_LANGUAGE = 'en';
 
+        function normalizeServerPath(value) {
+          if (typeof value !== 'string') {
+            return null;
+          }
+          const sentinel = '__LECTURE_TOOLS_ROOT_PATH__';
+          if (value === sentinel) {
+            return null;
+          }
+          let normalized = value.trim();
+          if (!normalized || normalized === '/') {
+            return '';
+          }
+          if (!normalized.startsWith('/')) {
+            normalized = `/${normalized}`;
+          }
+          return normalized.replace(/\/+$/, '') || '';
+        }
+
         const BASE_PATH = (() => {
+          const serverPath = normalizeServerPath(
+            window.__LECTURE_TOOLS_SERVER_ROOT_PATH__,
+          );
+          if (serverPath !== null) {
+            return serverPath;
+          }
           const { pathname } = window.location;
           if (!pathname || pathname === '/' || pathname === '/index.html') {
             return '';

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -55,6 +55,27 @@ def test_api_handles_configured_root_path(temp_config):
     assert response.status_code == 200
 
 
+def test_index_injects_configured_root_path(temp_config):
+    repository, _lecture_id, _module_id = _create_sample_data(temp_config)
+    app = create_app(repository, config=temp_config, root_path="/lecture")
+    client = TestClient(app)
+
+    response = client.get("/lecture/")
+    assert response.status_code == 200
+    assert "__LECTURE_TOOLS_ROOT_PATH__" not in response.text
+    assert 'window.__LECTURE_TOOLS_SERVER_ROOT_PATH__ = "/lecture";' in response.text
+
+
+def test_index_injects_empty_root_path(temp_config):
+    repository, _lecture_id, _module_id = _create_sample_data(temp_config)
+    app = create_app(repository, config=temp_config)
+    client = TestClient(app)
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'window.__LECTURE_TOOLS_SERVER_ROOT_PATH__ = "";' in response.text
+
+
 def test_api_honors_forwarded_prefix_header(temp_config):
     repository, _lecture_id, _module_id = _create_sample_data(temp_config)
     app = create_app(repository, config=temp_config)


### PR DESCRIPTION
## Summary
- embed the server's detected root path in the delivered SPA so the client can resolve API URLs reliably
- update the SPA to honour the injected root path (including empty prefixes) before falling back to window location heuristics
- add regression tests covering HTML root path injection for prefixed and non-prefixed deployments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3636d041083309d3db5d680e6fbfa