### PR TITLE
Improve audio upload pipeline and UI

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -83,6 +83,7 @@ class Bootstrapper:
                     description TEXT DEFAULT '',
                     position INTEGER NOT NULL DEFAULT 0,
                     audio_path TEXT,
+                    processed_audio_path TEXT,
                     slide_path TEXT,
                     transcript_path TEXT,
                     notes_path TEXT,
@@ -94,12 +95,13 @@ class Bootstrapper:
             )
             connection.commit()
 
-            try:
-                cursor.execute("ALTER TABLE lectures ADD COLUMN notes_path TEXT")
-            except sqlite3.OperationalError as error:
-                message = str(error).lower()
-                if "duplicate column name" not in message:
-                    raise
+            for column in ("notes_path", "processed_audio_path"):
+                try:
+                    cursor.execute(f"ALTER TABLE lectures ADD COLUMN {column} TEXT")
+                except sqlite3.OperationalError as error:
+                    message = str(error).lower()
+                    if "duplicate column name" not in message:
+                        raise
 
             def _column_exists(table: str, column: str) -> bool:
                 cursor.execute(f"PRAGMA table_info({table})")

--- a/app/processing/__init__.py
+++ b/app/processing/__init__.py
@@ -7,17 +7,17 @@ from .audio import (
     GPUWhisperUnsupportedError,
     check_gpu_whisper_availability,
 )
-from .recording import AudioRecorder, preprocess_audio, save_preprocessed_wav
+from .recording import load_wav_file, preprocess_audio, save_preprocessed_wav
 from .slides import PyMuPDFSlideConverter
 
 __all__ = [
-    "AudioRecorder",
     "FasterWhisperTranscription",
     "GPUWhisperError",
     "GPUWhisperModelMissingError",
     "GPUWhisperUnsupportedError",
     "check_gpu_whisper_availability",
     "PyMuPDFSlideConverter",
+    "load_wav_file",
     "preprocess_audio",
     "save_preprocessed_wav",
 ]

--- a/app/services/ingestion.py
+++ b/app/services/ingestion.py
@@ -57,6 +57,7 @@ class LecturePaths:
     lecture_root: Path
     raw_dir: Path
     processed_dir: Path
+    processed_audio_dir: Path
     transcript_dir: Path
     slide_dir: Path
     notes_dir: Path
@@ -74,6 +75,7 @@ class LecturePaths:
         )
         raw_dir = lecture_root / "raw"
         processed_dir = lecture_root / "processed"
+        processed_audio_dir = processed_dir / "audio"
         transcript_dir = processed_dir / "transcripts"
         slide_dir = processed_dir / "slides"
         notes_dir = processed_dir / "notes"
@@ -81,6 +83,7 @@ class LecturePaths:
             lecture_root=lecture_root,
             raw_dir=raw_dir,
             processed_dir=processed_dir,
+            processed_audio_dir=processed_audio_dir,
             transcript_dir=transcript_dir,
             slide_dir=slide_dir,
             notes_dir=notes_dir,
@@ -91,6 +94,7 @@ class LecturePaths:
             self.lecture_root,
             self.raw_dir,
             self.processed_dir,
+            self.processed_audio_dir,
             self.transcript_dir,
             self.slide_dir,
             self.notes_dir,

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -35,6 +35,7 @@ class LectureRecord:
     description: str
     position: int
     audio_path: Optional[str]
+    processed_audio_path: Optional[str]
     slide_path: Optional[str]
     transcript_path: Optional[str]
     notes_path: Optional[str]
@@ -129,6 +130,7 @@ class LectureRepository:
         description: str = "",
         *,
         audio_path: Optional[str] = None,
+        processed_audio_path: Optional[str] = None,
         slide_path: Optional[str] = None,
         transcript_path: Optional[str] = None,
         notes_path: Optional[str] = None,
@@ -146,11 +148,12 @@ class LectureRepository:
                     description,
                     position,
                     audio_path,
+                    processed_audio_path,
                     slide_path,
                     transcript_path,
                     notes_path,
                     slide_image_dir
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     module_id,
@@ -158,6 +161,7 @@ class LectureRepository:
                     description,
                     position,
                     audio_path,
+                    processed_audio_path,
                     slide_path,
                     transcript_path,
                     notes_path,
@@ -170,7 +174,18 @@ class LectureRepository:
         with self._connect() as connection:
             cursor = connection.execute(
                 """
-                SELECT id, module_id, name, description, position, audio_path, slide_path, transcript_path, notes_path, slide_image_dir
+                SELECT
+                    id,
+                    module_id,
+                    name,
+                    description,
+                    position,
+                    audio_path,
+                    processed_audio_path,
+                    slide_path,
+                    transcript_path,
+                    notes_path,
+                    slide_image_dir
                 FROM lectures
                 WHERE module_id = ? AND name = ?
                 """,
@@ -208,7 +223,18 @@ class LectureRepository:
         with self._connect() as connection:
             cursor = connection.execute(
                 """
-                SELECT id, module_id, name, description, position, audio_path, slide_path, transcript_path, notes_path, slide_image_dir
+                SELECT
+                    id,
+                    module_id,
+                    name,
+                    description,
+                    position,
+                    audio_path,
+                    processed_audio_path,
+                    slide_path,
+                    transcript_path,
+                    notes_path,
+                    slide_image_dir
                 FROM lectures
                 WHERE module_id = ?
                 ORDER BY position, id
@@ -240,7 +266,18 @@ class LectureRepository:
         with self._connect() as connection:
             cursor = connection.execute(
                 """
-                SELECT id, module_id, name, description, position, audio_path, slide_path, transcript_path, notes_path, slide_image_dir
+                SELECT
+                    id,
+                    module_id,
+                    name,
+                    description,
+                    position,
+                    audio_path,
+                    processed_audio_path,
+                    slide_path,
+                    transcript_path,
+                    notes_path,
+                    slide_image_dir
                 FROM lectures WHERE id = ?
                 """,
                 (lecture_id,),
@@ -302,6 +339,7 @@ class LectureRepository:
         lecture_id: int,
         *,
         audio_path: Optional[str] | object = _MISSING,
+        processed_audio_path: Optional[str] | object = _MISSING,
         slide_path: Optional[str] | object = _MISSING,
         transcript_path: Optional[str] | object = _MISSING,
         notes_path: Optional[str] | object = _MISSING,
@@ -317,6 +355,9 @@ class LectureRepository:
         if audio_path is not _MISSING:
             assignments.append("audio_path = ?")
             params.append(audio_path)
+        if processed_audio_path is not _MISSING:
+            assignments.append("processed_audio_path = ?")
+            params.append(processed_audio_path)
         if slide_path is not _MISSING:
             assignments.append("slide_path = ?")
             params.append(slide_path)

--- a/app/ui/overview.py
+++ b/app/ui/overview.py
@@ -10,6 +10,7 @@ from ..services.storage import ClassRecord, LectureRecord, LectureRepository, Mo
 
 ASSET_LABELS: Dict[str, str] = {
     "audio": "🎧 Audio",
+    "processed_audio": "🎚️ Mastered Audio",
     "slides": "📑 Slides",
     "transcript": "📝 Transcript",
     "notes": "📄 Notes",
@@ -83,6 +84,9 @@ def _extract_assets(
     if lecture_record.audio_path:
         assets.append(ASSET_LABELS["audio"])
         asset_totals["audio"] += 1
+    if lecture_record.processed_audio_path:
+        assets.append(ASSET_LABELS["processed_audio"])
+        asset_totals["processed_audio"] += 1
     if lecture_record.slide_path:
         assets.append(ASSET_LABELS["slides"])
         asset_totals["slides"] += 1

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -1761,6 +1761,7 @@
               },
               labels: {
                 audio: 'Audio',
+                masteredAudio: 'Mastered audio',
                 slides: 'Slides (PDF)',
                 transcript: 'Transcript',
                 notes: 'Notes',
@@ -1773,6 +1774,7 @@
                 linked: 'Linked: {{name}}',
                 linkedSlides: 'Linked: {{name}} (auto processed)',
                 archiveCreated: 'Archive created: {{name}}',
+                mastered: 'Mastered: {{name}}',
               },
               actions: {
                 upload: 'Upload',
@@ -1911,6 +1913,7 @@
               transcripts: 'Transcripts',
               slideDecks: 'Slide decks',
               audio: 'Audio files',
+              processedAudio: 'Mastered audio',
               notes: 'Notes',
               slideArchives: 'Slide archives',
             },
@@ -2089,6 +2092,7 @@
               },
               labels: {
                 audio: '音频',
+                masteredAudio: '优化音频',
                 slides: '课件（PDF）',
                 transcript: '逐字稿',
                 notes: '笔记',
@@ -2101,6 +2105,7 @@
                 linked: '已关联：{{name}}',
                 linkedSlides: '已关联：{{name}}（自动处理）',
                 archiveCreated: '已生成压缩包：{{name}}',
+                mastered: '已优化：{{name}}',
               },
               actions: {
                 upload: '上传',
@@ -2237,6 +2242,7 @@
               transcripts: '逐字稿',
               slideDecks: '课件',
               audio: '音频文件',
+              processedAudio: '优化音频',
               notes: '笔记',
               slideArchives: '课件压缩包',
             },
@@ -2415,6 +2421,7 @@
               },
               labels: {
                 audio: 'Audio',
+                masteredAudio: 'Audio masterizado',
                 slides: 'Diapositivas (PDF)',
                 transcript: 'Transcripción',
                 notes: 'Notas',
@@ -2427,6 +2434,7 @@
                 linked: 'Vinculado: {{name}}',
                 linkedSlides: 'Vinculado: {{name}} (procesado automáticamente)',
                 archiveCreated: 'Archivo creado: {{name}}',
+                mastered: 'Masterizado: {{name}}',
               },
               actions: {
                 upload: 'Subir',
@@ -2565,6 +2573,7 @@
               transcripts: 'Transcripciones',
               slideDecks: 'Presentaciones',
               audio: 'Archivos de audio',
+              processedAudio: 'Audio masterizado',
               notes: 'Notas',
               slideArchives: 'Archivos de diapositivas',
             },
@@ -2744,6 +2753,7 @@
               },
               labels: {
                 audio: 'Audio',
+                masteredAudio: 'Audio masterisé',
                 slides: 'Diapositives (PDF)',
                 transcript: 'Transcription',
                 notes: 'Notes',
@@ -2756,6 +2766,7 @@
                 linked: 'Lié : {{name}}',
                 linkedSlides: 'Lié : {{name}} (traitement automatique)',
                 archiveCreated: 'Archive créée : {{name}}',
+                mastered: 'Masterisé : {{name}}',
               },
               actions: {
                 upload: 'Importer',
@@ -2894,6 +2905,7 @@
               transcripts: 'Transcriptions',
               slideDecks: 'Présentations',
               audio: 'Fichiers audio',
+              processedAudio: 'Audio masterisé',
               notes: 'Notes',
               slideArchives: 'Archives de diapositives',
             },
@@ -3264,6 +3276,8 @@
           },
           transcriptionProgressTimer: null,
           transcriptionProgressLectureId: null,
+          processingProgressTimer: null,
+          processingProgressLectureId: null,
           lastProgressMessage: '',
           lastProgressRatio: null,
           statusHideTimer: null,
@@ -3724,6 +3738,13 @@
             labelKey: 'assets.labels.audio',
             accept: 'audio/*,video/*,*/*',
             type: 'audio',
+          },
+          {
+            key: 'processed_audio_path',
+            labelKey: 'assets.labels.masteredAudio',
+            accept: null,
+            type: 'processed_audio',
+            reveal: 'file',
           },
           {
             key: 'slide_path',
@@ -4212,12 +4233,39 @@
           }
         }
 
+        async function fetchProcessingProgress(lectureId) {
+          if (!lectureId) {
+            return null;
+          }
+          try {
+            const payload = await request(
+              `/api/lectures/${lectureId}/processing-progress`,
+            );
+            return payload?.progress || null;
+          } catch (error) {
+            return null;
+          }
+        }
+
         function stopTranscriptionProgress({ preserveMessage = false } = {}) {
           if (state.transcriptionProgressTimer !== null) {
             window.clearInterval(state.transcriptionProgressTimer);
           }
           state.transcriptionProgressTimer = null;
           state.transcriptionProgressLectureId = null;
+          if (!preserveMessage) {
+            state.lastProgressMessage = '';
+            state.lastProgressRatio = null;
+            resetStatusProgress();
+          }
+        }
+
+        function stopProcessingProgress({ preserveMessage = false } = {}) {
+          if (state.processingProgressTimer !== null) {
+            window.clearInterval(state.processingProgressTimer);
+          }
+          state.processingProgressTimer = null;
+          state.processingProgressLectureId = null;
           if (!preserveMessage) {
             state.lastProgressMessage = '';
             state.lastProgressRatio = null;
@@ -4266,6 +4314,22 @@
           };
           poll();
           state.transcriptionProgressTimer = window.setInterval(poll, 1200);
+        }
+
+        function startProcessingProgress(lectureId) {
+          stopProcessingProgress();
+          if (!lectureId) {
+            return;
+          }
+          state.processingProgressLectureId = lectureId;
+          const poll = async () => {
+            const progress = await fetchProcessingProgress(lectureId);
+            if (progress) {
+              handleProgressUpdate(progress);
+            }
+          };
+          poll();
+          state.processingProgressTimer = window.setInterval(poll, 900);
         }
 
         function clearDetailPanel() {
@@ -4339,6 +4403,7 @@
             [t('stats.transcripts'), stats.transcript_count],
             [t('stats.slideDecks'), stats.slide_count],
             [t('stats.audio'), stats.audio_count],
+            [t('stats.processedAudio'), stats.processed_audio_count],
             [t('stats.notes'), stats.notes_count],
             [t('stats.slideArchives'), stats.slide_image_count],
           ];
@@ -5271,6 +5336,8 @@
                 statusText = t('assets.status.linkedSlides', { name: fileName });
               } else if (definition.type === 'slide_images') {
                 statusText = t('assets.status.archiveCreated', { name: fileName });
+              } else if (definition.type === 'processed_audio') {
+                statusText = t('assets.status.mastered', { name: fileName });
               } else {
                 statusText = t('assets.status.linked', { name: fileName });
               }
@@ -5424,10 +5491,19 @@
           if (!state.selectedLectureId) {
             return;
           }
+          const lectureId = state.selectedLectureId;
           const formData = new FormData();
           formData.append('file', file);
           try {
-            await request(`/api/lectures/${state.selectedLectureId}/assets/${kind}`, {
+            if (kind === 'audio') {
+              stopTranscriptionProgress();
+              stopProcessingProgress();
+              state.lastProgressMessage = '';
+              state.lastProgressRatio = null;
+              startProcessingProgress(lectureId);
+            }
+
+            await request(`/api/lectures/${lectureId}/assets/${kind}`, {
               method: 'POST',
               body: formData,
             });
@@ -5435,10 +5511,18 @@
               kind === 'slides'
                 ? t('status.slidesProcessed')
                 : t('status.assetUploaded');
-            showStatus(successMessage, 'success');
+            if (kind !== 'audio') {
+              showStatus(successMessage, 'success');
+            }
             await refreshData();
-            await selectLecture(state.selectedLectureId);
+            await selectLecture(lectureId);
+            if (kind === 'audio') {
+              stopProcessingProgress({ preserveMessage: true });
+            }
           } catch (error) {
+            if (kind === 'audio') {
+              stopProcessingProgress();
+            }
             showStatus(error.message, 'error');
           }
         }

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import numpy as np
 
-from app.processing.recording import preprocess_audio, save_preprocessed_wav
+from app.processing.recording import (
+    load_wav_file,
+    preprocess_audio,
+    save_preprocessed_wav,
+)
 
 
 def test_preprocess_audio_generates_balanced_mono(tmp_path: Path) -> None:
@@ -22,9 +26,9 @@ def test_preprocess_audio_generates_balanced_mono(tmp_path: Path) -> None:
 
     assert processed.ndim == 1
     assert processed.dtype == np.float32
-    assert np.max(np.abs(processed)) <= 0.75
+    assert np.max(np.abs(processed)) <= 0.92
     rms = float(np.sqrt(np.mean(np.square(processed))))
-    assert 0.05 <= rms <= 0.2
+    assert 0.02 <= rms <= 0.12
 
     target = tmp_path / "processed.wav"
     save_preprocessed_wav(target, processed, sample_rate)
@@ -35,3 +39,24 @@ def test_preprocess_audio_generates_balanced_mono(tmp_path: Path) -> None:
         assert handle.getframerate() == sample_rate
         frames = handle.readframes(handle.getnframes())
         assert frames  # ensure data was written
+
+
+def test_load_wav_file_round_trip(tmp_path: Path) -> None:
+    sample_rate = 16_000
+    duration = 0.2
+    times = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    waveform = (0.5 * np.sin(2 * np.pi * 220 * times)).astype(np.float32)
+    ints = np.round(np.clip(waveform, -1.0, 1.0) * 32_767).astype(np.int16)
+
+    target = tmp_path / "tone.wav"
+    with wave.open(str(target), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(ints.tobytes())
+
+    loaded, rate = load_wav_file(target)
+    assert rate == sample_rate
+    assert loaded.shape == waveform.shape
+    assert loaded.dtype == np.float32
+    assert np.allclose(loaded[:100], waveform[:100], atol=1e-3)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -22,6 +22,7 @@ def test_repository_crud_cycle(temp_config: AppConfig) -> None:
     assert retrieved_lecture is not None
     assert retrieved_lecture.name == "Newton's Laws"
     assert retrieved_lecture.audio_path == "raw/audio.mp3"
+    assert retrieved_lecture.processed_audio_path is None
     assert retrieved_lecture.notes_path == "processed/notes.docx"
 
     modules = list(repository.iter_modules(class_id))
@@ -85,6 +86,7 @@ def test_repository_lookup_helpers(temp_config: AppConfig) -> None:
     repository.update_lecture_assets(
         lecture_id,
         audio_path="raw/derivatives.mp3",
+        processed_audio_path="processed/master.wav",
         slide_path="raw/derivatives.pdf",
         transcript_path="processed/transcript.txt",
         notes_path="processed/notes.docx",
@@ -95,6 +97,7 @@ def test_repository_lookup_helpers(temp_config: AppConfig) -> None:
     assert lecture is not None
     assert lecture.description == "Differential calculus"
     assert lecture.audio_path == "raw/derivatives.mp3"
+    assert lecture.processed_audio_path == "processed/master.wav"
     assert lecture.slide_image_dir == "processed/slides"
     assert lecture.notes_path == "processed/notes.docx"
 


### PR DESCRIPTION
## Summary
- replace the unused AudioRecorder helper with a reusable WAV loader and enhanced mastering pipeline that denoises, compresses, and normalises uploads
- store mastered audio alongside raw recordings, update the API to preprocess uploads, expose progress updates, and prefer mastered files for transcription
- surface mastered audio in the UI with status-bar progress polling plus refreshed translations and statistics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d406832acc8330aa61fc0719179af5