### PR TITLE
Handle whitespace-only input in installer prompts

### DIFF
--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -22,15 +22,27 @@ require_cmd() {
   fi
 }
 
+trim_whitespace() {
+  local value=$1
+  while [[ -n $value && $value == [[:space:]]* ]]; do
+    value=${value#?}
+  done
+  while [[ -n $value && $value == *[[:space:]] ]]; do
+    value=${value%?}
+  done
+  printf '%s' "$value"
+}
+
 prompt_default() {
-  local prompt default reply
+  local prompt default reply trimmed
   prompt=$1
   default=$2
   read -r -p "$prompt [$default]: " reply || true
-  if [[ -z $reply ]]; then
+  trimmed=$(trim_whitespace "${reply:-}")
+  if [[ -z $trimmed ]]; then
     printf '%s' "$default"
   else
-    printf '%s' "$reply"
+    printf '%s' "$trimmed"
   fi
 }
 


### PR DESCRIPTION
## Summary
- trim leading and trailing whitespace from responses to installer prompts
- treat whitespace-only responses as acceptance of the default value to avoid false space errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d44a2b799083309fd8ef00e73fd9cb