### PR TITLE
Support automatic WAV conversion for uploaded audio

### DIFF
--- a/app/services/audio_conversion.py
+++ b/app/services/audio_conversion.py
@@ -1,0 +1,94 @@
+"""Helpers for normalising uploaded audio files."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .naming import build_timestamped_name
+
+
+def ensure_wav(
+    source: Path,
+    *,
+    output_dir: Optional[Path] = None,
+    stem: Optional[str] = None,
+    timestamp: Optional[str] = None,
+) -> Tuple[Path, bool]:
+    """Return a PCM WAV version of *source*.
+
+    The original file is returned unchanged when it already uses the WAV container.
+    Otherwise FFmpeg is invoked to transcode the payload to a 16-bit PCM WAV file.
+
+    The returned tuple contains the destination path and a boolean flag indicating
+    whether a new file was created.
+    """
+
+    if source.suffix.lower() == ".wav":
+        return source, False
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise ValueError(
+            "Audio conversion requires FFmpeg to be installed on the server."
+        )
+
+    destination_dir = (output_dir or source.parent).resolve()
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    base_stem = stem or source.stem or "audio"
+    candidate = destination_dir / f"{base_stem}.wav"
+
+    if candidate.exists():
+        if timestamp:
+            candidate = destination_dir / build_timestamped_name(
+                base_stem, timestamp=timestamp, extension=".wav"
+            )
+        if candidate.exists():
+            sequence = 1
+            while True:
+                candidate = destination_dir / build_timestamped_name(
+                    base_stem,
+                    timestamp=timestamp,
+                    sequence=sequence,
+                    extension=".wav",
+                )
+                if not candidate.exists():
+                    break
+                sequence += 1
+
+    command = [
+        ffmpeg_path,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(source),
+        "-c:a",
+        "pcm_s16le",
+        str(candidate),
+    ]
+
+    try:
+        completed = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+        )
+    except FileNotFoundError as error:  # pragma: no cover - defensive guard
+        raise ValueError("Audio conversion requires FFmpeg to be installed on the server.") from error
+
+    if completed.returncode != 0:
+        candidate.unlink(missing_ok=True)
+        stderr = completed.stderr.decode("utf-8", errors="ignore").strip()
+        stdout = completed.stdout.decode("utf-8", errors="ignore").strip()
+        details = (stderr or stdout or "FFmpeg exited with a non-zero status.").splitlines()
+        raise ValueError(
+            f"Unable to convert audio to WAV: {details[0] if details else 'Unknown error.'}"
+        )
+
+    return candidate, True
+
+
+__all__ = ["ensure_wav"]

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -1760,7 +1760,7 @@
                 gpu: 'GPU (hardware accelerated)',
               },
               labels: {
-                audio: 'Audio',
+                audio: 'Audio (.wav, .mp3, .m4a, .aac, .flac, .ogg, .opus)',
                 masteredAudio: 'Mastered audio',
                 slides: 'Slides (PDF)',
                 transcript: 'Transcript',
@@ -2091,7 +2091,7 @@
                 gpu: 'GPU（硬件加速）',
               },
               labels: {
-                audio: '音频',
+                audio: '音频（.wav、.mp3、.m4a、.aac、.flac、.ogg、.opus）',
                 masteredAudio: '优化音频',
                 slides: '课件（PDF）',
                 transcript: '逐字稿',
@@ -2420,7 +2420,7 @@
                 gpu: 'GPU (acelerado por hardware)',
               },
               labels: {
-                audio: 'Audio',
+                audio: 'Audio (.wav, .mp3, .m4a, .aac, .flac, .ogg, .opus)',
                 masteredAudio: 'Audio masterizado',
                 slides: 'Diapositivas (PDF)',
                 transcript: 'Transcripción',
@@ -2752,7 +2752,7 @@
                 gpu: 'GPU (accélération matérielle)',
               },
               labels: {
-                audio: 'Audio',
+                audio: 'Audio (.wav, .mp3, .m4a, .aac, .flac, .ogg, .opus)',
                 masteredAudio: 'Audio masterisé',
                 slides: 'Diapositives (PDF)',
                 transcript: 'Transcription',
@@ -3736,7 +3736,7 @@
           {
             key: 'audio_path',
             labelKey: 'assets.labels.audio',
-            accept: 'audio/*,video/*,*/*',
+            accept: 'audio/*,.wav,.mp3,.m4a,.aac,.flac,.ogg,.oga,.opus',
             type: 'audio',
           },
           {


### PR DESCRIPTION
## Summary
- add an FFmpeg-backed helper that converts uploaded audio files to 16-bit PCM WAV
- integrate the conversion step into the audio upload endpoint and update supported UI labels/extensions
- cover the conversion flow with a dedicated API test alongside the existing mastering test

## Testing
- pytest tests/test_web_api.py::test_upload_audio_processes_file tests/test_web_api.py::test_upload_audio_converts_non_wav

------
https://chatgpt.com/codex/tasks/task_e_68d455ba28108330bf66bb0d7d510587