### PR TITLE
Use public ECR mirror for python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.11-slim AS base
+# Use the AWS hosted mirror of the official Python image to avoid Docker Hub
+# authentication/rate limiting issues when building the container in
+# environments without Docker Hub credentials.
+FROM public.ecr.aws/docker/library/python:3.11-slim AS base
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1


### PR DESCRIPTION
## Summary
- switch the Docker base image to the AWS public ECR mirror of python:3.11-slim
- document the change inline to explain avoiding Docker Hub authentication failures during updates

## Testing
- not run (docker is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d486bb2f908330be62c5c83eb4e304