### PR TITLE
Fix slide range dialog init order

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -3500,6 +3500,8 @@
           return String(count);
         }
 
+        let activeSlideRangeDialog = null;
+
         function applyTranslations(language) {
           currentLanguage = language && translations[language] ? language : DEFAULT_LANGUAGE;
           const locale = getLocale(currentLanguage);
@@ -4268,7 +4270,6 @@
         }
 
         const dialogState = { active: false };
-        let activeSlideRangeDialog = null;
 
         function syncSettingsForm(settings) {
           const themeValue = settings?.theme ?? 'system';


### PR DESCRIPTION
## Summary
- declare `activeSlideRangeDialog` before translation logic to avoid referencing the binding in its temporal dead zone
- ensure translation updates can safely touch the slide-range dialog if it exists

## Testing
- python run.py serve --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68d493d324448330a53b0372359601d4