### PR TITLE
Fix upload dialog file selection

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -251,7 +251,7 @@
       }
 
       .upload-dropzone button {
-        pointer-events: none;
+        pointer-events: auto;
       }
 
       .upload-file-info {
@@ -4820,6 +4820,9 @@
                 dialog.dropzone.removeEventListener('dragleave', handleDragLeave);
                 dialog.dropzone.removeEventListener('drop', handleDrop);
               }
+              if (dialog.browse) {
+                dialog.browse.removeEventListener('click', handleBrowseClick);
+              }
               if (dialog.input) {
                 dialog.input.removeEventListener('change', handleInputChange);
               }
@@ -5089,6 +5092,7 @@
 
             function handleBrowseClick(event) {
               event?.preventDefault?.();
+              event?.stopPropagation?.();
               if (dialog.input) {
                 dialog.input.click();
               }
@@ -5296,6 +5300,9 @@
               dialog.dropzone.addEventListener('dragover', handleDragOver);
               dialog.dropzone.addEventListener('dragleave', handleDragLeave);
               dialog.dropzone.addEventListener('drop', handleDrop);
+            }
+            if (dialog.browse) {
+              dialog.browse.addEventListener('click', handleBrowseClick);
             }
             if (dialog.input) {
               dialog.input.addEventListener('change', handleInputChange);


### PR DESCRIPTION
## Summary
- allow the upload dialog browse button to receive pointer events so it can be clicked directly
- wire the browse button into the existing file-selection handler and ensure its listener is removed during cleanup
- prevent duplicate click handling by stopping event propagation when triggering the hidden file input

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4addd8ec08330ae95aa4698f97026