### PR TITLE
Add audio mastering CLI availability probe

### DIFF
--- a/app/processing/__init__.py
+++ b/app/processing/__init__.py
@@ -7,7 +7,12 @@ from .audio import (
     GPUWhisperUnsupportedError,
     check_gpu_whisper_availability,
 )
-from .recording import load_wav_file, preprocess_audio, save_preprocessed_wav
+from .recording import (
+    check_audio_mastering_cli_availability,
+    load_wav_file,
+    preprocess_audio,
+    save_preprocessed_wav,
+)
 from .slides import PyMuPDFSlideConverter
 
 __all__ = [
@@ -16,6 +21,7 @@ __all__ = [
     "GPUWhisperModelMissingError",
     "GPUWhisperUnsupportedError",
     "check_gpu_whisper_availability",
+    "check_audio_mastering_cli_availability",
     "PyMuPDFSlideConverter",
     "load_wav_file",
     "preprocess_audio",


### PR DESCRIPTION
## Summary
- add utilities to detect and report availability of the audio mastering CLI
- expose the probe through the processing package exports
- cover the new helper with unit tests that verify success and failure scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d555b7e3fc8330bc176e333558a76a