### PR TITLE
Add CLI command for audio mastering diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,18 +189,19 @@ During transcription, Lecture Tools automatically benchmarks GPU availability an
 
 ### 🎧 Verify the audio mastering CLI (optional)
 
-The Windows-friendly mastering helper that ships under `cli/` can be tested without launching the full app. Run the diagnostic probe to confirm the binary is detected and functional:
+Run the mastering pipeline end-to-end against a sample file to confirm the helper binary works on your machine:
 
 ```bash
-python - <<'PY'
-from pprint import pprint
-from app.processing import check_audio_mastering_cli_availability
-
-pprint(check_audio_mastering_cli_availability())
-PY
+python run.py test-mastering path/to/audio.wav
 ```
 
-A healthy setup reports `{"supported": True, ...}` along with the resolved binary path and the banner text emitted by the helper. If the binary is missing or incompatible for your OS, the message field explains what to fix (for example, copying an updated `main.exe` into `cli/`).
+Prefer a flag-style invocation? The command also understands `-testmastering`:
+
+```bash
+python run.py -testmastering path/to/audio.wav
+```
+
+Progress mirrors the web upload flow, reporting each step (analysis, noise reduction, render). When the run completes the terminal prints the mastered file location alongside the untouched original.
 
 ---
 

--- a/tests/test_cli_mastering.py
+++ b/tests/test_cli_mastering.py
@@ -1,0 +1,60 @@
+"""Tests for the standalone audio mastering command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from typer.testing import CliRunner
+
+import run
+
+
+runner = CliRunner()
+
+
+def test_mastering_command_reports_progress(monkeypatch, tmp_path) -> None:
+    audio_path = tmp_path / "input.wav"
+    audio_path.write_bytes(b"fake")
+
+    class DummyConfig:
+        def __init__(self, storage_root: Path) -> None:
+            self.storage_root = storage_root
+
+    dummy_config = DummyConfig(tmp_path / "logs")
+
+    monkeypatch.setattr(run, "initialize_app", lambda: dummy_config)
+    monkeypatch.setattr(run, "_prepare_logging", lambda _: None)
+
+    calls: dict[str, object] = {}
+
+    def fake_ensure_wav(path: Path, **_: object) -> tuple[Path, bool]:
+        calls["ensure_wav"] = path
+        return path, False
+
+    def fake_load_wav(path: Path) -> tuple[np.ndarray, int]:
+        calls["load_wav"] = path
+        return np.zeros(4, dtype=np.float32), 16_000
+
+    def fake_preprocess(audio: np.ndarray, sample_rate: int) -> np.ndarray:
+        calls["preprocess"] = (audio.copy(), sample_rate)
+        return np.ones_like(audio)
+
+    def fake_save(target: Path, audio: np.ndarray, sample_rate: int) -> None:
+        calls["save"] = (target, audio.copy(), sample_rate)
+
+    monkeypatch.setattr(run, "ensure_wav", fake_ensure_wav)
+    monkeypatch.setattr(run, "load_wav_file", fake_load_wav)
+    monkeypatch.setattr(run, "preprocess_audio", fake_preprocess)
+    monkeypatch.setattr(run, "save_preprocessed_wav", fake_save)
+
+    result = runner.invoke(run.cli, ["test-mastering", str(audio_path)])
+
+    assert result.exit_code == 0
+    assert "====> Preparing audio mastering…" in result.stdout
+    assert "====> Analysing uploaded audio…" in result.stdout
+    assert "====> Audio mastering completed." in result.stdout
+    assert str(audio_path) in result.stdout
+
+    saved_target, _, _ = calls["save"]
+    assert saved_target == audio_path.parent / "input-master.wav"


### PR DESCRIPTION
## Summary
- add a `test-mastering` Typer command (with a `-testmastering` alias) that runs the mastering pipeline on a given audio file and reports progress
- document the new command in the README so users can validate their mastering setup locally
- cover the command with a CLI test that verifies progress output and generated file naming

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d56212a37483308b8f24137a6db7ba