### PR TITLE
Fix default root path handling when auto-serving

### DIFF
--- a/run.py
+++ b/run.py
@@ -65,7 +65,7 @@ def main(ctx: typer.Context) -> None:
     """Launch the web server when no explicit command is provided."""
 
     if ctx.invoked_subcommand is None:
-        ctx.invoke(serve, host=DEFAULT_HOST, port=DEFAULT_PORT)
+        ctx.invoke(serve, host=DEFAULT_HOST, port=DEFAULT_PORT, root_path=None)
 
 
 DEFAULT_HOST = "127.0.0.1"


### PR DESCRIPTION
## Summary
- ensure the implicit `serve` invocation passes `root_path=None` so Typer does not forward an OptionInfo object
- prevent AttributeError when launching the app without explicit CLI commands

## Testing
- python run.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d564ec49908330a9660a8004758e33