### PR TITLE
Fix server activity pane growth

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -296,6 +296,9 @@
         gap: 6px;
         font-size: 0.8rem;
         color: rgba(226, 232, 240, 0.85);
+        flex-shrink: 0;
+        max-height: 180px;
+        overflow-y: auto;
       }
 
       .debug-stream-header {


### PR DESCRIPTION
## Summary
- keep the server activity feed from shrinking the main debug log
- constrain the activity panel height and enable scrolling when messages overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d57c9f5b008330ac494b6fdda58e6d