### PR TITLE
Add detailed mastering debug logs

### DIFF
--- a/app/processing/__init__.py
+++ b/app/processing/__init__.py
@@ -9,6 +9,7 @@ from .audio import (
 )
 from .recording import (
     check_audio_mastering_cli_availability,
+    describe_audio_debug_stats,
     load_wav_file,
     preprocess_audio,
     save_preprocessed_wav,
@@ -23,6 +24,7 @@ __all__ = [
     "check_gpu_whisper_availability",
     "check_audio_mastering_cli_availability",
     "PyMuPDFSlideConverter",
+    "describe_audio_debug_stats",
     "load_wav_file",
     "preprocess_audio",
     "save_preprocessed_wav",

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -31,6 +31,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from ..config import AppConfig
 from ..processing import (
     PyMuPDFSlideConverter,
+    describe_audio_debug_stats,
     load_wav_file,
     preprocess_audio,
     save_preprocessed_wav,
@@ -1491,6 +1492,12 @@ def create_app(
                         "====> Analysing uploaded audio…",
                     )
                     samples, sample_rate = load_wav_file(target)
+                    if LOGGER.isEnabledFor(logging.DEBUG):
+                        LOGGER.debug(
+                            "Audio mastering diagnostics before preprocessing for lecture %s: %s",
+                            lecture_id,
+                            describe_audio_debug_stats(samples, sample_rate),
+                        )
                     processing_tracker.update(
                         lecture_id,
                         1.5,
@@ -1498,6 +1505,12 @@ def create_app(
                         "====> Reducing background noise and balancing speech…",
                     )
                     processed = preprocess_audio(samples, sample_rate)
+                    if LOGGER.isEnabledFor(logging.DEBUG):
+                        LOGGER.debug(
+                            "Audio mastering diagnostics after preprocessing for lecture %s: %s",
+                            lecture_id,
+                            describe_audio_debug_stats(processed, sample_rate),
+                        )
                     processing_tracker.update(
                         lecture_id,
                         2.5,

--- a/run.py
+++ b/run.py
@@ -20,6 +20,7 @@ from app.logging_utils import DEFAULT_LOG_FORMAT, configure_logging, get_log_fil
 from app.processing import (
     FasterWhisperTranscription,
     PyMuPDFSlideConverter,
+    describe_audio_debug_stats,
     load_wav_file,
     preprocess_audio,
     save_preprocessed_wav,
@@ -31,6 +32,9 @@ from app.services.storage import LectureRepository
 from app.ui.console import ConsoleUI
 from app.ui.modern import ModernUI
 from app.web import create_app
+
+
+LOGGER = logging.getLogger("lecture_tools.mastering")
 
 
 cli = typer.Typer(add_completion=False, help="Lecture Tools management commands")
@@ -180,9 +184,21 @@ def test_mastering(
 
         typer.echo("====> Analysing uploaded audio…")
         samples, sample_rate = load_wav_file(wav_path)
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug(
+                "Audio mastering diagnostics before preprocessing for '%s': %s",
+                audio_path,
+                describe_audio_debug_stats(samples, sample_rate),
+            )
 
         typer.echo("====> Reducing background noise and balancing speech…")
         processed = preprocess_audio(samples, sample_rate)
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug(
+                "Audio mastering diagnostics after preprocessing for '%s': %s",
+                audio_path,
+                describe_audio_debug_stats(processed, sample_rate),
+            )
 
         typer.echo("====> Rendering mastered waveform…")
         base_stem = audio_path.stem or "audio"


### PR DESCRIPTION
## Summary
- add a reusable helper that summarises audio statistics for debugging
- emit detailed before/after mastering diagnostics in the CLI and web mastering flows
- expose the new helper through the processing package for other components

## Testing
- pytest tests/test_cli_mastering.py

------
https://chatgpt.com/codex/tasks/task_e_68d58963a1ec8330b477a10bc05eb1f5