### PR TITLE
Fix mastering CLI audio argument handling

### DIFF
--- a/run.py
+++ b/run.py
@@ -155,16 +155,43 @@ def overview(style: UIStyle = style_option) -> None:
 
 @cli.command("test-mastering")
 def test_mastering(
-    audio: Path = typer.Argument(
-        ..., exists=True, file_okay=True, dir_okay=False, resolve_path=True
+    audio: Optional[str] = typer.Argument(
+        None,
+        help="Path to the audio file that should be mastered.",
+    ),
+    audio_option: Optional[str] = typer.Option(
+        None,
+        "--audio",
+        "-a",
+        help="Path to the audio file that should be mastered.",
     ),
 ) -> None:
     """Run the mastering pipeline on *audio* and report progress."""
 
+    raw_audio = audio
+    if raw_audio is not None and audio_option is not None:
+        raise typer.BadParameter(
+            "Provide the audio file either as a positional argument or via --audio, not both.",
+            param_hint="AUDIO",
+        )
+    if raw_audio is None:
+        raw_audio = audio_option
+    if raw_audio is None:
+        raise typer.BadParameter(
+            "Missing required audio file argument.",
+            param_hint="AUDIO",
+        )
+
+    audio_path = Path(raw_audio).expanduser()
+    if not audio_path.exists() or not audio_path.is_file():
+        raise typer.BadParameter(
+            f"File '{audio_path}' does not exist or is not a file.",
+            param_hint="AUDIO",
+        )
+    audio_path = audio_path.resolve()
+
     config = initialize_app()
     _prepare_logging(config.storage_root)
-
-    audio_path = audio.resolve()
     typer.echo("====> Preparing audio mastering…")
     typer.echo(f"Source audio: {audio_path}")
 

--- a/tests/test_cli_mastering.py
+++ b/tests/test_cli_mastering.py
@@ -58,3 +58,34 @@ def test_mastering_command_reports_progress(monkeypatch, tmp_path) -> None:
 
     saved_target, _, _ = calls["save"]
     assert saved_target == audio_path.parent / "input-master.wav"
+
+
+def test_mastering_accepts_audio_option(monkeypatch, tmp_path) -> None:
+    audio_path = tmp_path / "input.mp3"
+    audio_path.write_bytes(b"fake")
+
+    class DummyConfig:
+        def __init__(self, storage_root: Path) -> None:
+            self.storage_root = storage_root
+
+    dummy_config = DummyConfig(tmp_path / "logs")
+
+    monkeypatch.setattr(run, "initialize_app", lambda: dummy_config)
+    monkeypatch.setattr(run, "_prepare_logging", lambda _: None)
+
+    monkeypatch.setattr(run, "ensure_wav", lambda *args, **kwargs: (audio_path, False))
+    monkeypatch.setattr(run, "load_wav_file", lambda _: (np.zeros(1, dtype=np.float32), 16_000))
+    monkeypatch.setattr(run, "preprocess_audio", lambda *args, **kwargs: np.zeros(1, dtype=np.float32))
+    monkeypatch.setattr(run, "save_preprocessed_wav", lambda *args, **kwargs: None)
+
+    result = runner.invoke(run.cli, ["test-mastering", "--audio", str(audio_path)])
+
+    assert result.exit_code == 0
+    assert "Source audio" in result.stdout
+
+
+def test_mastering_requires_audio_argument() -> None:
+    result = runner.invoke(run.cli, ["test-mastering"])
+
+    assert result.exit_code != 0
+    assert "Missing required audio file argument" in result.stdout


### PR DESCRIPTION
## Summary
- allow the test-mastering command to accept the audio file path either positionally or via --audio/-a
- perform our own path validation to avoid click parsing issues with Windows paths
- extend CLI tests to cover the new option-based invocation and missing-argument error handling

## Testing
- pytest tests/test_cli_mastering.py

------
https://chatgpt.com/codex/tasks/task_e_68d58d3c02fc8330ab639e7889db5d1e