### PR TITLE
Improve mastering progress logging

### DIFF
--- a/app/processing/__init__.py
+++ b/app/processing/__init__.py
@@ -8,8 +8,10 @@ from .audio import (
     check_gpu_whisper_availability,
 )
 from .recording import (
+    PreprocessAudioStageDescription,
     check_audio_mastering_cli_availability,
     describe_audio_debug_stats,
+    describe_preprocess_audio_stage,
     load_wav_file,
     preprocess_audio,
     save_preprocessed_wav,
@@ -25,7 +27,9 @@ __all__ = [
     "check_audio_mastering_cli_availability",
     "PyMuPDFSlideConverter",
     "describe_audio_debug_stats",
+    "describe_preprocess_audio_stage",
     "load_wav_file",
     "preprocess_audio",
+    "PreprocessAudioStageDescription",
     "save_preprocessed_wav",
 ]

--- a/app/services/progress.py
+++ b/app/services/progress.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple
+
+from app.processing.recording import (
+    PreprocessAudioStageDescription,
+    describe_preprocess_audio_stage,
+)
 
 
 # The mastering pipeline consists of four major stages that are surfaced to the
@@ -35,4 +40,40 @@ def format_progress_message(
     clamped = max(0.0, min(ratio, 1.0))
     percent = int(round(clamped * 100))
     return f"{message} ({percent}%)"
+
+
+def build_mastering_stage_progress_message(
+    completed_steps: Optional[float],
+    total_steps: Optional[float],
+) -> Tuple[str, PreprocessAudioStageDescription, Optional[int], Optional[int]]:
+    """Return a descriptive progress message for the mastering stage."""
+
+    description = describe_preprocess_audio_stage()
+
+    stage_index: Optional[int] = None
+    if completed_steps is not None:
+        try:
+            stage_index = int(float(completed_steps)) + 1
+        except (TypeError, ValueError):  # Defensive guard against bad inputs
+            stage_index = None
+
+    total_count: Optional[int] = None
+    if total_steps not in {None, 0}:
+        try:
+            total_count = int(float(total_steps))
+        except (TypeError, ValueError):
+            total_count = None
+
+    if stage_index is not None and total_count is not None:
+        summary = f"Stage {stage_index}/{total_count} – {description.summary}"
+    else:
+        summary = description.summary
+
+    message = f"====> {summary}: {description.headline}…"
+    return (
+        format_progress_message(message, completed_steps, total_steps),
+        description,
+        stage_index,
+        total_count,
+    )
 


### PR DESCRIPTION
## Summary
- add a structured description of the audio mastering stage so its operations and parameters can be surfaced to callers
- update CLI and web mastering progress updates to use the new helper and log detailed stage steps instead of the vague background-noise message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59a240b408330b2959f810f4a79e1