### PR TITLE
Gracefully degrade slide processing when PyMuPDF is unavailable

### DIFF
--- a/app/processing/__init__.py
+++ b/app/processing/__init__.py
@@ -16,7 +16,7 @@ from .recording import (
     preprocess_audio,
     save_preprocessed_wav,
 )
-from .slides import PyMuPDFSlideConverter
+from .slides import PyMuPDFSlideConverter, SlideConversionDependencyError, SlideConversionError
 
 __all__ = [
     "FasterWhisperTranscription",
@@ -26,6 +26,8 @@ __all__ = [
     "check_gpu_whisper_availability",
     "check_audio_mastering_cli_availability",
     "PyMuPDFSlideConverter",
+    "SlideConversionDependencyError",
+    "SlideConversionError",
     "describe_audio_debug_stats",
     "describe_preprocess_audio_stage",
     "load_wav_file",

--- a/app/processing/slides.py
+++ b/app/processing/slides.py
@@ -16,6 +16,14 @@ from ..services.ingestion import SlideConverter
 LOGGER = logging.getLogger(__name__)
 
 
+class SlideConversionError(RuntimeError):
+    """Base class for slide conversion errors."""
+
+
+class SlideConversionDependencyError(SlideConversionError):
+    """Raised when the configured converter cannot operate due to a missing dependency."""
+
+
 class PyMuPDFSlideConverter(SlideConverter):
     """Slide converter that renders PDF slides via :mod:`PyMuPDF`."""
 
@@ -40,7 +48,7 @@ class PyMuPDFSlideConverter(SlideConverter):
         try:
             import fitz  # type: ignore
         except ImportError as exc:  # pragma: no cover - runtime check
-            raise RuntimeError("PyMuPDF (fitz) is not installed") from exc
+            raise SlideConversionDependencyError("PyMuPDF (fitz) is not installed") from exc
 
         output_dir.mkdir(parents=True, exist_ok=True)
         scale = self._dpi / 72
@@ -100,4 +108,8 @@ class PyMuPDFSlideConverter(SlideConverter):
         return candidate
 
 
-__all__ = ["PyMuPDFSlideConverter"]
+__all__ = [
+    "PyMuPDFSlideConverter",
+    "SlideConversionDependencyError",
+    "SlideConversionError",
+]


### PR DESCRIPTION
## Summary
- add dedicated slide conversion exceptions and expose them via the processing package
- reuse existing slide archives or skip generation when PyMuPDF is missing so PDF uploads still succeed
- extend API tests to cover the graceful fallback for both asset and process endpoints

## Testing
- pytest tests/test_web_api.py::test_upload_slides_gracefully_handles_missing_converter -q
- pytest tests/test_web_api.py::test_process_slides_gracefully_handles_missing_converter -q
- pytest tests/test_web_api.py -k slides --maxfail=1 -q

------
https://chatgpt.com/codex/tasks/task_e_68d5e3f87fac8330b396a80aca51ec1f