### PR TITLE
Fix PDF preview module MIME type

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import mimetypes
 import platform
 import shutil
 import stat
@@ -75,6 +76,11 @@ _DEFAULT_UI_SETTINGS = UISettings()
 _SERVER_LOGGER_PREFIXES: Tuple[str, ...] = ("uvicorn", "gunicorn", "hypercorn", "werkzeug")
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Ensure PDF.js module assets are served with the correct MIME type for dynamic import.
+mimetypes.add_type("text/javascript", ".mjs")
+mimetypes.add_type("application/javascript", ".mjs")
 
 
 class DebugLogHandler(logging.Handler):


### PR DESCRIPTION
## Summary
- ensure FastAPI serves PDF.js module assets with a JavaScript MIME type so the browser can import them for the preview dialog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c8a885d08330b7ffbebf6b657235