### PR TITLE
Guard PDF inspection with timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Open `http://SERVER_IP:PORT/` once the installer finishes. If you configure a re
 - **Port mapping** – Adjust the `8000:8000` mapping in `docker-compose.yml` when exposing a different port.
 - **Reverse proxies** – When terminating TLS with Nginx/Traefik, forward to the container and ensure the `LECTURE_TOOLS_ROOT_PATH` environment variable matches any prefix you inject (e.g. `/lecture`).
 - **Custom images** – Build and push your own tag with `docker build -t registry.example.com/lecture-tools:latest .` and update the compose file to reference it.
+- **Slide previews without MuPDF** – Uploads only wait a few seconds for PyMuPDF to report the page count; if inspection times out or the dependency is missing the upload succeeds (page totals omitted) and the metadata endpoint returns HTTP 503 instead of hanging.
 
 ### ♻️ Updating
 


### PR DESCRIPTION
## Summary
- wrap slide preview page counting in asyncio.to_thread with a short timeout so uploads complete even if PyMuPDF stalls
- extend the metadata endpoint to use the same guarded call and surface a timeout as HTTP 503
- document the new fallback and add regression tests that simulate a hanging get_pdf_page_count implementation

## Testing
- pytest tests/test_web_api.py -k "slide_preview"

------
https://chatgpt.com/codex/tasks/task_e_68d8675151588330ad4f419049fcd0f9