### PR TITLE
Handle missing FFmpeg during audio upload

### DIFF
--- a/app/services/audio_conversion.py
+++ b/app/services/audio_conversion.py
@@ -111,4 +111,10 @@ def ensure_wav(
     return candidate, True
 
 
-__all__ = ["ensure_wav"]
+def ffmpeg_available() -> bool:
+    """Return ``True`` when an FFmpeg binary is discoverable."""
+
+    return shutil.which("ffmpeg") is not None
+
+
+__all__ = ["ensure_wav", "ffmpeg_available"]


### PR DESCRIPTION
## Summary
- add an `ffmpeg_available` helper and guard audio uploads that require conversion when FFmpeg is unavailable
- trigger slide archive generation immediately after PDF uploads while logging unexpected conversion failures
- update API tests to cover the FFmpeg preflight check and patch the new helper where needed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86cb526f48330891cacf08a5db0ed