### PR TITLE
Process slide uploads in background

### DIFF
--- a/app/services/audio_conversion.py
+++ b/app/services/audio_conversion.py
@@ -111,4 +111,10 @@ def ensure_wav(
     return candidate, True
 
 
-__all__ = ["ensure_wav"]
+def ffmpeg_available() -> bool:
+    """Return ``True`` when an FFmpeg binary is discoverable."""
+
+    return shutil.which("ffmpeg") is not None
+
+
+__all__ = ["ensure_wav", "ffmpeg_available"]

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Deque, Dict, List, Literal, Optional, Set, Tuple
 
+from concurrent.futures import Future, ThreadPoolExecutor
+
 from fastapi import (
     FastAPI,
     HTTPException,
@@ -53,7 +55,7 @@ from ..processing import (
     render_pdf_page,
     save_preprocessed_wav,
 )
-from ..services.audio_conversion import ensure_wav
+from ..services.audio_conversion import ensure_wav, ffmpeg_available
 from ..services.ingestion import LecturePaths
 from ..services.naming import build_asset_stem, build_timestamped_name, slugify
 from ..services.progress import (
@@ -800,6 +802,27 @@ def create_app(
     settings_store = SettingsStore(config)
     progress_tracker = TranscriptionProgressTracker()
     processing_tracker = TranscriptionProgressTracker()
+
+    background_executor = ThreadPoolExecutor(
+        max_workers=2,
+        thread_name_prefix="lecture-tools-background",
+    )
+    background_jobs: Set[Future] = set()
+    background_jobs_lock = threading.Lock()
+
+    app.state.background_executor = background_executor
+    app.state.background_jobs = background_jobs
+    app.state.background_jobs_lock = background_jobs_lock
+    # Backwards compatibility for extensions that still look up audio-specific
+    # executor attributes on the application state.
+    app.state.audio_mastering_executor = background_executor
+    app.state.audio_mastering_jobs = background_jobs
+    app.state.audio_mastering_jobs_lock = background_jobs_lock
+
+    def _shutdown_background_executor() -> None:
+        background_executor.shutdown(wait=True, cancel_futures=True)
+
+    app.add_event_handler("shutdown", _shutdown_background_executor)
     app.state.progress_tracker = progress_tracker
     app.state.processing_tracker = processing_tracker
     gpu_support_state: Dict[str, Any] = {
@@ -1676,6 +1699,19 @@ def create_app(
             candidate_name = build_timestamped_name(stem, timestamp=timestamp, extension=suffix)
             target = destination / candidate_name
 
+        if asset_key == "audio":
+            normalized_suffix = suffix.lower()
+            requires_conversion = normalized_suffix not in {".wav"}
+            if requires_conversion and not ffmpeg_available():
+                await file.close()
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "FFmpeg is required to convert audio files on this server. "
+                        "Install FFmpeg or upload a WAV file instead."
+                    ),
+                )
+
         try:
             with target.open("wb") as buffer:
                 shutil.copyfileobj(file.file, buffer)
@@ -1685,7 +1721,73 @@ def create_app(
         relative = target.relative_to(config.storage_root).as_posix()
         update_kwargs: Dict[str, Optional[str]] = {attribute: relative}
         processed_relative: Optional[str] = None
-        completion_message: Optional[str] = None
+        processing_queued = False
+        pending_background_jobs: List[Callable[[], None]] = []
+
+        def _queue_background_job(
+            job: Callable[[], None],
+            *,
+            queue_label: str,
+            fail_detail: str,
+            on_submit_error: Optional[Callable[[Exception], None]] = None,
+        ) -> None:
+            executor = getattr(
+                app.state,
+                "background_executor",
+                getattr(app.state, "audio_mastering_executor", None),
+            )
+            jobs = getattr(
+                app.state,
+                "background_jobs",
+                getattr(app.state, "audio_mastering_jobs", None),
+            )
+            jobs_lock = getattr(
+                app.state,
+                "background_jobs_lock",
+                getattr(app.state, "audio_mastering_jobs_lock", None),
+            )
+            if executor is None or jobs is None or jobs_lock is None:
+                LOGGER.error(
+                    "Background executor unavailable while queuing %s for lecture %s",
+                    queue_label,
+                    lecture_id,
+                )
+                if on_submit_error is not None:
+                    try:
+                        on_submit_error(RuntimeError("Background executor unavailable"))
+                    except Exception:  # noqa: BLE001 - best-effort notification
+                        LOGGER.exception(
+                            "Background job submit error handler failed for %s",
+                            queue_label,
+                        )
+                raise HTTPException(status_code=503, detail=fail_detail)
+
+            try:
+                future = executor.submit(job)
+            except Exception as error:  # noqa: BLE001 - executor may raise
+                if on_submit_error is not None:
+                    try:
+                        on_submit_error(error)
+                    except Exception:  # noqa: BLE001 - avoid masking original error
+                        LOGGER.exception(
+                            "Background job submit error handler failed for %s",
+                            queue_label,
+                        )
+                LOGGER.exception(
+                    "Failed to queue %s for lecture %s",
+                    queue_label,
+                    lecture_id,
+                )
+                raise HTTPException(status_code=500, detail=fail_detail) from error
+
+            with jobs_lock:
+                jobs.add(future)
+
+            def _cleanup_future(done: Future) -> None:
+                with jobs_lock:
+                    jobs.discard(done)
+
+            future.add_done_callback(_cleanup_future)
 
         if asset_key == "audio":
             original_target = target
@@ -1705,6 +1807,7 @@ def create_app(
                 candidate_name = target.name
                 relative = target.relative_to(config.storage_root).as_posix()
                 update_kwargs[attribute] = relative
+                update_kwargs["processed_audio_path"] = None
                 if converted:
                     with contextlib.suppress(OSError):
                         original_target.unlink(missing_ok=True)
@@ -1713,6 +1816,7 @@ def create_app(
             audio_mastering_enabled = getattr(settings, "audio_mastering_enabled", True)
 
             if audio_mastering_enabled:
+                processing_queued = True
                 total_steps = float(AUDIO_MASTERING_TOTAL_STEPS)
                 processing_tracker.start(
                     lecture_id,
@@ -1723,6 +1827,9 @@ def create_app(
                     ),
                     context={"operation": "audio_mastering"},
                 )
+
+                target_path = target
+                base_stem = Path(candidate_name).stem if candidate_name else stem
 
                 def _process_audio() -> Tuple[str, str]:
                     completed_steps = 1.0
@@ -1736,7 +1843,7 @@ def create_app(
                             total_steps,
                         ),
                     )
-                    samples, sample_rate = load_wav_file(target)
+                    samples, sample_rate = load_wav_file(target_path)
                     if LOGGER.isEnabledFor(logging.DEBUG):
                         LOGGER.debug(
                             "Audio mastering diagnostics before preprocessing for lecture %s: %s",
@@ -1795,7 +1902,6 @@ def create_app(
                     )
 
                     lecture_paths.processed_audio_dir.mkdir(parents=True, exist_ok=True)
-                    base_stem = Path(candidate_name).stem if candidate_name else stem
                     processed_name = f"{base_stem}-master.wav"
                     processed_target = lecture_paths.processed_audio_dir / processed_name
                     if processed_target.exists():
@@ -1807,9 +1913,9 @@ def create_app(
                         processed_target = lecture_paths.processed_audio_dir / processed_name
 
                     save_preprocessed_wav(processed_target, processed, sample_rate)
-                    if processed_target != target:
+                    if processed_target != target_path:
                         with contextlib.suppress(OSError):
-                            target.unlink(missing_ok=True)
+                            target_path.unlink(missing_ok=True)
                     completed_steps = total_steps
                     completion_message = format_progress_message(
                         "====> Audio mastering completed.",
@@ -1827,44 +1933,179 @@ def create_app(
                         completion_message,
                     )
 
-                try:
-                    processed_relative, completion_message = await asyncio.to_thread(
-                        _process_audio
-                    )
-                except ValueError as error:
-                    processing_tracker.fail(lecture_id, f"====> {error}")
-                    raise HTTPException(status_code=400, detail=str(error)) from error
-                except Exception as error:  # noqa: BLE001 - processing may raise
-                    processing_tracker.fail(lecture_id, f"====> {error}")
-                    raise HTTPException(status_code=500, detail=str(error)) from error
-                else:
-                    if completion_message is None:
-                        completion_message = format_progress_message(
-                            "====> Audio mastering completed.",
-                            total_steps,
-                            total_steps,
+                def _run_mastering_job() -> None:
+                    try:
+                        processed_path, completion = _process_audio()
+                    except ValueError as error:
+                        LOGGER.warning(
+                            "Audio mastering failed for lecture %s: %s",
+                            lecture_id,
+                            error,
                         )
-                    processing_tracker.finish(lecture_id, completion_message)
-                    relative = processed_relative
-                    update_kwargs[attribute] = processed_relative
-                    update_kwargs["processed_audio_path"] = processed_relative
+                        processing_tracker.fail(lecture_id, f"====> {error}")
+                        return
+                    except Exception as error:  # noqa: BLE001 - processing may raise
+                        LOGGER.exception(
+                            "Audio mastering crashed for lecture %s", lecture_id
+                        )
+                        processing_tracker.fail(lecture_id, f"====> {error}")
+                        return
+                    processing_tracker.finish(lecture_id, completion)
+                    try:
+                        repository.update_lecture_assets(
+                            lecture_id,
+                            **{
+                                attribute: processed_path,
+                                "processed_audio_path": processed_path,
+                            },
+                        )
+                    except Exception:  # noqa: BLE001 - repository update may fail
+                        LOGGER.exception(
+                            "Failed to update lecture %s with mastered audio path",
+                            lecture_id,
+                        )
+                    else:
+                        _log_event(
+                            "Audio mastering completed",
+                            lecture_id=lecture_id,
+                            path=processed_path,
+                        )
+
+                def _enqueue_mastering_job() -> None:
+                    def _on_submit_error(error: Exception) -> None:
+                        processing_tracker.fail(lecture_id, f"====> {error}")
+
+                    _queue_background_job(
+                        _run_mastering_job,
+                        queue_label="audio mastering",
+                        fail_detail="Unable to queue audio mastering task.",
+                        on_submit_error=_on_submit_error,
+                    )
+                    _log_event(
+                        "Audio mastering queued", lecture_id=lecture_id, path=relative
+                    )
+
+                pending_background_jobs.append(_enqueue_mastering_job)
             else:
                 update_kwargs["processed_audio_path"] = None
 
         if asset_key == "slides":
             if lecture.slide_image_dir:
                 _delete_asset_path(lecture.slide_image_dir)
+            processing_queued = True
             update_kwargs["slide_image_dir"] = None
+            processing_tracker.start(
+                lecture_id,
+                "====> Preparing slide conversion…",
+                context={"operation": "slide_conversion"},
+            )
+
+            def _enqueue_slide_job() -> None:
+                progress_total: Optional[float] = None
+
+                def _handle_slide_progress(
+                    processed_count: int, total_count: Optional[int]
+                ) -> None:
+                    nonlocal progress_total
+                    if total_count and total_count > 0:
+                        progress_total = float(total_count)
+                        current = float(max(0, min(processed_count, total_count)))
+                        processing_tracker.update(
+                            lecture_id,
+                            current,
+                            progress_total,
+                            format_progress_message(
+                                "====> Rendering slide images…",
+                                current,
+                                progress_total,
+                            ),
+                        )
+                    else:
+                        processing_tracker.note(
+                            lecture_id,
+                            "====> Rendering slide images…",
+                        )
+
+                def _run_slide_conversion() -> None:
+                    try:
+                        slide_image_relative = _generate_slide_archive(
+                            target,
+                            lecture_paths,
+                            _make_slide_converter(),
+                            progress_callback=_handle_slide_progress,
+                        )
+                    except HTTPException as error:
+                        detail = getattr(error, "detail", str(error))
+                        processing_tracker.fail(lecture_id, f"====> {detail}")
+                        LOGGER.warning(
+                            "Slide conversion failed during upload for lecture %s: %s",
+                            lecture_id,
+                            detail,
+                        )
+                        return
+                    except Exception as error:  # noqa: BLE001 - conversion may raise
+                        processing_tracker.fail(lecture_id, f"====> {error}")
+                        LOGGER.exception(
+                            "Slide conversion crashed during upload for lecture %s",
+                            lecture_id,
+                        )
+                        return
+
+                    if progress_total and progress_total > 0:
+                        completion_message = format_progress_message(
+                            "====> Slide conversion completed.",
+                            progress_total,
+                            progress_total,
+                        )
+                    else:
+                        completion_message = "====> Slide conversion completed."
+                    processing_tracker.finish(lecture_id, completion_message)
+
+                    try:
+                        repository.update_lecture_assets(
+                            lecture_id,
+                            slide_image_dir=slide_image_relative,
+                        )
+                    except Exception:  # noqa: BLE001 - repository update may fail
+                        LOGGER.exception(
+                            "Failed to update lecture %s with slide conversion result",
+                            lecture_id,
+                        )
+                    else:
+                        _log_event(
+                            "Slides processed",
+                            lecture_id=lecture_id,
+                            slide_path=relative,
+                            slide_image_dir=slide_image_relative,
+                        )
+
+                def _on_submit_error(error: Exception) -> None:
+                    processing_tracker.fail(lecture_id, f"====> {error}")
+
+                _queue_background_job(
+                    _run_slide_conversion,
+                    queue_label="slide conversion",
+                    fail_detail="Unable to queue slide conversion task.",
+                    on_submit_error=_on_submit_error,
+                )
+                _log_event(
+                    "Slide conversion queued", lecture_id=lecture_id, path=relative
+                )
+
+            pending_background_jobs.append(_enqueue_slide_job)
 
         repository.update_lecture_assets(lecture_id, **update_kwargs)
         updated = repository.get_lecture(lecture_id)
         if updated is None:
             raise HTTPException(status_code=500, detail="Lecture update failed")
+        for job in pending_background_jobs:
+            job()
         response: Dict[str, Any] = {"lecture": _serialize_lecture(updated), attribute: relative}
         if asset_key == "audio":
             response["processed_audio_path"] = processed_relative
         if asset_key == "slides":
             response["slide_image_dir"] = update_kwargs.get("slide_image_dir")
+        response["processing"] = processing_queued
         _log_event(
             "Uploaded asset",
             lecture_id=lecture_id,

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -9618,16 +9618,25 @@
           const lectureId = state.selectedLectureId;
           const kind = definition.type;
           const assetLabel = t(definition.labelKey);
-          let audioProcessingStarted = false;
+          let processingProgressStarted = false;
 
           const allowAudioBackground =
             kind === 'audio' && state.settings?.audio_mastering_enabled !== false;
-          const allowBackgroundProcessing = allowAudioBackground;
+          const allowSlideBackground = kind === 'slides';
+          const allowBackgroundProcessing = allowAudioBackground || allowSlideBackground;
           const enableProcessingStage = allowBackgroundProcessing;
           const processingLabel =
-            kind === 'audio' ? t('dialogs.upload.processingAudio') : undefined;
+            kind === 'audio'
+              ? t('dialogs.upload.processingAudio')
+              : kind === 'slides'
+              ? t('dialogs.upload.processingSlides')
+              : undefined;
           const backgroundProcessingLabel =
-            kind === 'audio' ? t('dialogs.upload.backgroundProcessing') : undefined;
+            kind === 'audio'
+              ? t('dialogs.upload.backgroundProcessing')
+              : kind === 'slides'
+              ? t('dialogs.upload.processingSlides')
+              : undefined;
 
           const dialogResult = await showUploadDialog({
             accept: definition.accept || '',
@@ -9651,14 +9660,16 @@
 
               if (kind === 'audio') {
                 stopTranscriptionProgress();
+              }
+              if (kind === 'audio' || kind === 'slides') {
                 stopProcessingProgress();
                 state.lastProgressMessage = '';
                 state.lastProgressRatio = null;
-                if (allowAudioBackground) {
+                if (allowBackgroundProcessing) {
                   startProcessingProgress(lectureId);
-                  audioProcessingStarted = true;
+                  processingProgressStarted = true;
                 } else {
-                  audioProcessingStarted = false;
+                  processingProgressStarted = false;
                 }
               }
 
@@ -9672,21 +9683,24 @@
                 });
                 return response;
               } catch (error) {
-                if (kind === 'audio' && audioProcessingStarted) {
+                if (processingProgressStarted) {
                   stopProcessingProgress();
-                  audioProcessingStarted = false;
+                  processingProgressStarted = false;
                 }
                 throw error;
               }
             },
           });
 
-          const backgroundProcessingActive = Boolean(dialogResult && dialogResult.processing);
+          const backgroundProcessingActive = Boolean(
+            (dialogResult && dialogResult.processing) ||
+              (dialogResult && dialogResult.result && dialogResult.result.processing)
+          );
 
           if (!dialogResult || (!dialogResult.uploaded && !backgroundProcessingActive)) {
-            if (kind === 'audio' && audioProcessingStarted) {
+            if (processingProgressStarted && !backgroundProcessingActive) {
               stopProcessingProgress();
-              audioProcessingStarted = false;
+              processingProgressStarted = false;
             }
             return;
           }
@@ -9695,9 +9709,9 @@
             if (!backgroundProcessingActive) {
               await refreshData();
               await selectLecture(lectureId);
-              if (kind === 'audio' && audioProcessingStarted) {
+              if (processingProgressStarted) {
                 stopProcessingProgress({ preserveMessage: true });
-                audioProcessingStarted = false;
+                processingProgressStarted = false;
               }
             }
             return;
@@ -9706,8 +9720,14 @@
           const successMessage =
             kind === 'slides' ? t('status.slidesUploaded') : t('status.assetUploaded');
           if (kind === 'audio') {
-            if (allowAudioBackground) {
+            if (allowAudioBackground && backgroundProcessingActive) {
               showStatus(t('status.audioProcessingQueued'), 'info', { persist: true });
+            } else {
+              showStatus(successMessage, 'success');
+            }
+          } else if (kind === 'slides') {
+            if (allowBackgroundProcessing && backgroundProcessingActive) {
+              showStatus(t('status.processingSlides'), 'info', { persist: true });
             } else {
               showStatus(successMessage, 'success');
             }
@@ -9716,9 +9736,9 @@
           }
           await refreshData();
           await selectLecture(lectureId);
-          if (kind === 'audio' && audioProcessingStarted && !backgroundProcessingActive) {
+          if (processingProgressStarted && !backgroundProcessingActive) {
             stopProcessingProgress({ preserveMessage: true });
-            audioProcessingStarted = false;
+            processingProgressStarted = false;
           }
         }
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -7,6 +7,7 @@ from typing import Any
 import io
 import time
 import wave
+from concurrent.futures import wait
 
 import pytest
 
@@ -76,6 +77,27 @@ def _build_wav_bytes(duration_seconds: float = 0.25, sample_rate: int = 16_000) 
         silence = b"\x00\x00" * frame_count
         handle.writeframes(silence)
     return buffer.getvalue()
+
+
+def _wait_for_background_jobs(app, timeout: float = 5.0) -> None:
+    jobs = getattr(app.state, "background_jobs", None)
+    lock = getattr(app.state, "background_jobs_lock", None)
+    if jobs is None or lock is None:
+        jobs = getattr(app.state, "audio_mastering_jobs", None)
+        lock = getattr(app.state, "audio_mastering_jobs_lock", None)
+    if jobs is None or lock is None:
+        return
+    deadline = time.time() + timeout
+    while True:
+        with lock:
+            pending = list(jobs)
+        if not pending:
+            return
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        wait(pending, timeout=min(0.2, remaining))
+    raise AssertionError("Audio mastering jobs did not finish before timeout")
 
 
 def test_api_handles_configured_root_path(temp_config):
@@ -469,10 +491,12 @@ def test_upload_asset_updates_repository(temp_config):
     assert repository.get_lecture(lecture_id).notes_path.endswith("summary.docx")
 
 
-def test_upload_audio_processes_file(temp_config):
+def test_upload_audio_processes_file(monkeypatch, temp_config):
     repository, lecture_id, _module_id = _create_sample_data(temp_config)
     app = create_app(repository, config=temp_config)
     client = TestClient(app)
+
+    monkeypatch.setattr(web_server, "ffmpeg_available", lambda: True)
 
     response = client.post(
         f"/api/lectures/{lecture_id}/assets/audio",
@@ -480,17 +504,26 @@ def test_upload_audio_processes_file(temp_config):
     )
     assert response.status_code == 200
     payload = response.json()
+    assert payload.get("processing") is True
     audio_relative = payload["audio_path"]
-    assert audio_relative.endswith("-master.wav")
-    processed_relative = payload.get("processed_audio_path")
-    assert processed_relative == audio_relative
-    processed_file = temp_config.storage_root / processed_relative
-    assert processed_file.exists()
+    assert audio_relative.endswith("lecture.wav")
+    assert payload.get("processed_audio_path") is None
+    raw_file = temp_config.storage_root / audio_relative
+    assert raw_file.exists()
 
     updated = repository.get_lecture(lecture_id)
     assert updated is not None
     assert updated.audio_path == audio_relative
-    assert updated.processed_audio_path == processed_relative
+    assert updated.processed_audio_path is None
+
+    _wait_for_background_jobs(app)
+
+    refreshed = repository.get_lecture(lecture_id)
+    assert refreshed is not None
+    assert refreshed.audio_path and refreshed.audio_path.endswith("-master.wav")
+    assert refreshed.processed_audio_path == refreshed.audio_path
+    processed_file = temp_config.storage_root / refreshed.processed_audio_path
+    assert processed_file.exists()
 
     progress_response = client.get(
         f"/api/lectures/{lecture_id}/processing-progress"
@@ -505,6 +538,8 @@ def test_upload_audio_converts_non_wav(monkeypatch, temp_config):
     repository, lecture_id, _module_id = _create_sample_data(temp_config)
     app = create_app(repository, config=temp_config)
     client = TestClient(app)
+
+    monkeypatch.setattr(web_server, "ffmpeg_available", lambda: True)
 
     def fake_ensure_wav(path, *, output_dir, stem, timestamp):
         destination = output_dir / f"{stem}-converted.wav"
@@ -521,18 +556,55 @@ def test_upload_audio_converts_non_wav(monkeypatch, temp_config):
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["audio_path"].endswith("-converted-master.wav")
+    assert payload.get("processing") is True
+    assert payload["audio_path"].endswith("-converted.wav")
+    assert payload.get("processed_audio_path") is None
     wav_path = temp_config.storage_root / payload["audio_path"]
     assert wav_path.exists()
     assert not (wav_path.parent / "lecture.mp3").exists()
 
     updated = repository.get_lecture(lecture_id)
     assert updated is not None
-    assert updated.audio_path and updated.audio_path.endswith("-converted-master.wav")
+    assert updated.audio_path and updated.audio_path.endswith("-converted.wav")
+    assert updated.processed_audio_path is None
 
-    processed_relative = payload.get("processed_audio_path")
-    assert processed_relative == payload["audio_path"]
+    _wait_for_background_jobs(app)
 
+    refreshed = repository.get_lecture(lecture_id)
+    assert refreshed is not None
+    assert refreshed.audio_path and refreshed.audio_path.endswith("-converted-master.wav")
+    assert refreshed.processed_audio_path == refreshed.audio_path
+
+
+def test_upload_audio_requires_ffmpeg(monkeypatch, temp_config):
+    repository, _existing_lecture_id, module_id = _create_sample_data(temp_config)
+    lecture_id = repository.add_lecture(module_id, "FFmpeg Check")
+    app = create_app(repository, config=temp_config)
+    client = TestClient(app)
+
+    monkeypatch.setattr(web_server, "ffmpeg_available", lambda: False)
+
+    response = client.post(
+        f"/api/lectures/{lecture_id}/assets/audio",
+        files={"file": ("lecture.mp3", b"id3", "audio/mpeg")},
+    )
+    assert response.status_code == 503
+    assert "FFmpeg" in response.json().get("detail", "")
+
+    lecture = repository.get_lecture(lecture_id)
+    assert lecture is not None
+    assert lecture.audio_path is None
+
+    module = repository.get_module(module_id)
+    class_record = repository.get_class(module.class_id) if module else None
+    assert module is not None and class_record is not None
+    lecture_paths = LecturePaths.build(
+        temp_config.storage_root,
+        class_record.name,
+        module.name,
+        "FFmpeg Check",
+    )
+    assert not any(lecture_paths.raw_dir.iterdir())
 
 def test_delete_asset_clears_path_and_file(temp_config):
     repository, lecture_id, _module_id = _create_sample_data(temp_config)
@@ -633,6 +705,7 @@ def test_upload_audio_respects_mastering_setting(temp_config):
     )
     assert response.status_code == 200
     payload = response.json()
+    assert payload.get("processing") is False
     assert payload.get("processed_audio_path") is None
     assert payload["audio_path"].endswith("lecture.wav")
     audio_file = temp_config.storage_root / payload["audio_path"]
@@ -666,12 +739,14 @@ def test_upload_slides_auto_generates_archive(monkeypatch, temp_config):
     assert response.status_code == 200
     payload = response.json()
     assert payload["slide_path"].endswith(".pdf")
-    assert payload["slide_image_dir"].endswith("slides.zip")
-    slide_asset = temp_config.storage_root / payload["slide_image_dir"]
-    assert slide_asset.exists()
+    assert payload.get("slide_image_dir") is None
+    assert payload.get("processing") is True
+    _wait_for_background_jobs(app)
     updated = repository.get_lecture(lecture_id)
     assert updated.slide_path and updated.slide_path.endswith("deck.pdf")
     assert updated.slide_image_dir and updated.slide_image_dir.endswith("slides.zip")
+    slide_asset = temp_config.storage_root / updated.slide_image_dir
+    assert slide_asset.exists()
 
 
 def test_upload_slides_gracefully_handles_missing_converter(monkeypatch, temp_config):
@@ -701,6 +776,11 @@ def test_upload_slides_gracefully_handles_missing_converter(monkeypatch, temp_co
     payload = response.json()
     assert payload["slide_path"].endswith(".pdf")
     assert payload.get("slide_image_dir") is None
+    assert payload.get("processing") is True
+    _wait_for_background_jobs(app)
+    refreshed = repository.get_lecture(lecture_id)
+    assert refreshed is not None
+    assert refreshed.slide_image_dir is None
 
 
 def test_process_slides_generates_archive(monkeypatch, temp_config):


### PR DESCRIPTION
## Summary
- share a background executor for long-running asset work and queue both audio mastering and slide conversion with richer progress tracking
- update the upload dialog to allow slide uploads to run in the background and show appropriate status messaging
- extend API tests to wait for background jobs and cover the new slide upload semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86cb526f48330891cacf08a5db0ed