### PR TITLE
Handle uvicorn without limit_max_request_size support

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import shutil
 import sys
@@ -118,7 +119,14 @@ def serve(
     config_kwargs = {}
     max_upload_bytes = get_max_upload_bytes()
     if max_upload_bytes > 0:
-        config_kwargs["limit_max_request_size"] = max_upload_bytes
+        config_signature = inspect.signature(uvicorn.Config.__init__)
+        if "limit_max_request_size" in config_signature.parameters:
+            config_kwargs["limit_max_request_size"] = max_upload_bytes
+        else:
+            LOGGER.warning(
+                "Ignoring max upload size limit; uvicorn.Config does not support "
+                "'limit_max_request_size'.",
+            )
 
     server_config = uvicorn.Config(
         app,


### PR DESCRIPTION
## Summary
- guard the uvicorn configuration to only set limit_max_request_size when supported
- log a warning when running with a uvicorn version that lacks the configuration option

## Testing
- python -m compileall run.py

------
https://chatgpt.com/codex/tasks/task_e_68d894d4d7608330a83ca21ebe8e15bf