### PR TITLE
Auto-close upload dialog at full progress

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -6365,6 +6365,7 @@
             let uploadResult = null;
             let uploadStage = 'idle';
             let processingInBackground = false;
+            let autoCloseOnComplete = false;
 
             const allowBackgroundProcessing = options.allowBackgroundProcessing === true;
             const enableProcessingStage = options.enableProcessingStage !== false;
@@ -6501,6 +6502,7 @@
               }
               uploadStage = 'idle';
               processingInBackground = false;
+              autoCloseOnComplete = false;
             }
 
             function updateProgress(ratio) {
@@ -6518,12 +6520,19 @@
               if (dialog.progress) {
                 dialog.progress.setAttribute('aria-valuenow', String(percent));
               }
+              if (percent >= 100) {
+                autoCloseOnComplete = true;
+                if (uploading && uploadStage === 'uploading') {
+                  setStatus(labels.success, 'success');
+                }
+              }
               if (
                 enableProcessingStage &&
                 labels.processing &&
                 uploading &&
                 uploadStage !== 'processing' &&
-                percent >= 100
+                percent >= 100 &&
+                !autoCloseOnComplete
               ) {
                 uploadStage = 'processing';
                 if (allowBackgroundProcessing) {
@@ -6870,12 +6879,24 @@
                 updateProgress(1);
                 setStatus(labels.success, 'success');
                 updateActionState();
+                if (autoCloseOnComplete) {
+                  autoCloseOnComplete = false;
+                  void resolveAndClose({
+                    confirmed: true,
+                    uploaded: true,
+                    file: selectedFile,
+                    result: uploadResult,
+                    meta: selectedMeta,
+                  });
+                  return;
+                }
               } catch (error) {
                 uploading = false;
                 uploadComplete = false;
                 uploadResult = null;
                 uploadStage = 'idle';
                 processingInBackground = false;
+                autoCloseOnComplete = false;
                 const message =
                   error instanceof Error && error.message ? error.message : labels.failure;
                 setStatus(message, 'error');


### PR DESCRIPTION
## Summary
- mark uploads as successful when progress reaches 100% and trigger the dialog to close automatically
- reset the auto-close flag on retries or failures so the upload dialog can be reused safely

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d89bb0d7708330afa8a42152d97a8d