### PR TITLE
Fix Docker upload limit by forcing h11 HTTP parser

### DIFF
--- a/run.py
+++ b/run.py
@@ -128,6 +128,14 @@ def serve(
     if limit_parameter is not None:
         effective_limit = max_upload_bytes if max_upload_bytes > 0 else sys.maxsize
         config_kwargs[limit_parameter] = effective_limit
+        if limit_parameter == "h11_max_incomplete_event_size":
+            # When uvicorn lacks native request size limiting support it defaults to
+            # the pure-Python ``h11`` implementation. The high-performance
+            # ``httptools`` HTTP parser enforces its own ~1MB body size limit which
+            # would prevent uploads from completing. Force the ``h11`` protocol so
+            # that the configured upload limit takes effect and large files are
+            # accepted consistently across platforms.
+            config_kwargs.setdefault("http", "h11")
     elif max_upload_bytes > 0:
         LOGGER.warning(
             "Ignoring max upload size limit; uvicorn.Config does not support the "


### PR DESCRIPTION
## Summary
- ensure large upload limits are enforced by forcing uvicorn to use the h11 HTTP implementation when only the legacy request size parameter is available
- extend the run entrypoint tests to cover the forced protocol selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8a736185c8330bc5194c25baf49ff