### PR TITLE
Force uvicorn to use h11 for large Docker uploads

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,7 +7,14 @@ from types import SimpleNamespace
 import run
 
 
-def _setup_serve(monkeypatch, tmp_path, upload_limit):
+def _setup_serve(
+    monkeypatch,
+    tmp_path,
+    upload_limit,
+    *,
+    support_limit_max: bool = True,
+    support_h11_limit: bool = True,
+):
     captured = {}
 
     monkeypatch.setattr(
@@ -21,25 +28,79 @@ def _setup_serve(monkeypatch, tmp_path, upload_limit):
     dummy_app = SimpleNamespace(state=SimpleNamespace())
     monkeypatch.setattr(run, "create_app", lambda repository, config, root_path: dummy_app)
 
-    class DummyConfig:
-        def __init__(
-            self,
-            app,
-            *,
-            limit_max_request_size=None,
-            h11_max_incomplete_event_size=None,
-            http=None,
-            **kwargs,
-        ):
-            captured["app"] = app
-            captured_kwargs = dict(kwargs)
-            if limit_max_request_size is not None:
-                captured_kwargs["limit_max_request_size"] = limit_max_request_size
-            if h11_max_incomplete_event_size is not None:
-                captured_kwargs["h11_max_incomplete_event_size"] = h11_max_incomplete_event_size
-            if http is not None:
-                captured_kwargs["http"] = http
-            captured["config_kwargs"] = captured_kwargs
+    if support_limit_max and support_h11_limit:
+        
+        class DummyConfig:
+            def __init__(
+                self,
+                app,
+                *,
+                limit_max_request_size=None,
+                h11_max_incomplete_event_size=None,
+                http=None,
+                **kwargs,
+            ):
+                captured["app"] = app
+                captured_kwargs = dict(kwargs)
+                if limit_max_request_size is not None:
+                    captured_kwargs["limit_max_request_size"] = limit_max_request_size
+                if h11_max_incomplete_event_size is not None:
+                    captured_kwargs["h11_max_incomplete_event_size"] = (
+                        h11_max_incomplete_event_size
+                    )
+                if http is not None:
+                    captured_kwargs["http"] = http
+                captured["config_kwargs"] = captured_kwargs
+
+    elif support_limit_max:
+
+        class DummyConfig:
+            def __init__(
+                self,
+                app,
+                *,
+                limit_max_request_size=None,
+                http=None,
+                **kwargs,
+            ):
+                captured["app"] = app
+                captured_kwargs = dict(kwargs)
+                if limit_max_request_size is not None:
+                    captured_kwargs["limit_max_request_size"] = limit_max_request_size
+                if http is not None:
+                    captured_kwargs["http"] = http
+                captured["config_kwargs"] = captured_kwargs
+
+    elif support_h11_limit:
+
+        class DummyConfig:
+            def __init__(
+                self,
+                app,
+                *,
+                h11_max_incomplete_event_size=None,
+                http=None,
+                **kwargs,
+            ):
+                captured["app"] = app
+                captured_kwargs = dict(kwargs)
+                if h11_max_incomplete_event_size is not None:
+                    captured_kwargs["h11_max_incomplete_event_size"] = (
+                        h11_max_incomplete_event_size
+                    )
+                if http is not None:
+                    captured_kwargs["http"] = http
+                captured["config_kwargs"] = captured_kwargs
+
+    else:
+
+        class DummyConfig:
+            def __init__(self, app, *, http=None, **kwargs):
+                captured["app"] = app
+                captured_kwargs = dict(kwargs)
+                if http is not None:
+                    captured_kwargs["http"] = http
+                captured["config_kwargs"] = captured_kwargs
 
     class DummyServer:
         def __init__(self, config):
@@ -84,6 +145,12 @@ def test_serve_applies_request_size_limit(monkeypatch, tmp_path):
     assert captured["app_state_server"] is captured["server_instance"]
 
 
+def test_serve_forces_h11_with_native_limit_support(monkeypatch, tmp_path):
+    captured = _setup_serve(monkeypatch, tmp_path, upload_limit=10 * 1024 * 1024)
+
+    assert captured["config_kwargs"].get("http") == "h11"
+
+
 def test_serve_uses_large_limit_when_disabled(monkeypatch, tmp_path):
     captured = _setup_serve(monkeypatch, tmp_path, upload_limit=0)
     limit_key = _get_limit_key(captured["config_kwargs"])
@@ -96,3 +163,15 @@ def test_serve_forces_h11_when_using_legacy_limit(monkeypatch, tmp_path):
     config_kwargs = captured["config_kwargs"]
     if "h11_max_incomplete_event_size" in config_kwargs:
         assert config_kwargs.get("http") == "h11"
+
+
+def test_serve_forces_h11_without_limit_support(monkeypatch, tmp_path):
+    captured = _setup_serve(
+        monkeypatch,
+        tmp_path,
+        upload_limit=5 * 1024 * 1024,
+        support_limit_max=False,
+        support_h11_limit=False,
+    )
+
+    assert captured["config_kwargs"].get("http") == "h11"


### PR DESCRIPTION
## Summary
- always run the web server with uvicorn's h11 HTTP implementation so Docker builds no longer hit httptools' ~1 MB body limit
- log the effective request size limit that is applied and keep enforcing the configured upload ceiling
- extend the run.py unit tests to cover the forced h11 behaviour across uvicorn configurations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8acb7ad348330bfe02eed672e3d76