### PR TITLE
Handle unwritable storage directories

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,10 +2,79 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Tuple
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+_PERMISSION_SENTINEL = ".lecture_tools_write_check"
+
+
+def _ensure_writable_directory(path: Path) -> bool:
+    """Return ``True`` if *path* can be created and written to."""
+
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+
+    test_file = path / _PERMISSION_SENTINEL
+    try:
+        with test_file.open("w", encoding="utf-8") as handle:
+            handle.write("ok")
+    except OSError:
+        return False
+    finally:
+        with contextlib.suppress(OSError):
+            test_file.unlink()
+
+    return True
+
+
+def _select_writable_directory(
+    preferred: Path,
+    *,
+    label: str,
+    fallbacks: Iterable[Path] = (),
+) -> Tuple[Path, bool]:
+    """Return a usable directory based on ``preferred`` and ``fallbacks``.
+
+    The helper attempts to create ``preferred`` and returns it when writable. If
+    the preferred location is unavailable, each candidate in ``fallbacks`` is
+    tried in order. The first writable fallback is returned along with a flag
+    indicating that a fallback was used. When no candidate can be prepared the
+    original ``preferred`` path is returned.
+    """
+
+    preferred = preferred.resolve()
+    if _ensure_writable_directory(preferred):
+        return preferred, False
+
+    for fallback in fallbacks:
+        candidate = fallback.resolve()
+        if candidate == preferred:
+            continue
+        if _ensure_writable_directory(candidate):
+            LOGGER.warning(
+                "Preferred %s directory '%s' is not writable; using fallback '%s'.",
+                label,
+                preferred,
+                candidate,
+            )
+            return candidate, True
+
+    LOGGER.warning(
+        "%s directory '%s' is not writable and no fallback is available.",
+        label.capitalize(),
+        preferred,
+    )
+    return preferred, False
 
 
 @dataclass(frozen=True)
@@ -24,9 +93,56 @@ class AppConfig:
 
     @classmethod
     def from_mapping(cls, mapping: Dict[str, Any], *, base_path: Path) -> "AppConfig":
-        storage_root = (base_path / mapping["storage_root"]).resolve()
+        preferred_storage = (base_path / mapping["storage_root"]).resolve()
+        storage_fallback = Path.home() / ".lecture_tools" / "storage"
+        storage_root, storage_fallback_used = _select_writable_directory(
+            preferred_storage,
+            label="storage",
+            fallbacks=(storage_fallback,),
+        )
+
         database_file = (base_path / mapping["database_file"]).resolve()
-        assets_root = (base_path / mapping["assets_root"]).resolve()
+
+        preferred_assets = (base_path / mapping["assets_root"]).resolve()
+        assets_root, _ = _select_writable_directory(
+            preferred_assets,
+            label="assets",
+            fallbacks=(storage_root / "_assets",),
+        )
+
+        if storage_fallback_used:
+            try:
+                relative_database = database_file.relative_to(preferred_storage)
+            except ValueError:
+                relative_database = None
+            if relative_database is not None:
+                fallback_database = (storage_root / relative_database).resolve()
+                if _ensure_writable_directory(fallback_database.parent):
+                    LOGGER.warning(
+                        "Preferred database location '%s' is not writable; using fallback '%s'.",
+                        database_file,
+                        fallback_database,
+                    )
+                    database_file = fallback_database
+
+        database_parent = database_file.parent
+        if not _ensure_writable_directory(database_parent):
+            fallback_database = (storage_root / database_file.name).resolve()
+            if fallback_database != database_file and _ensure_writable_directory(
+                fallback_database.parent
+            ):
+                LOGGER.warning(
+                    "Preferred database location '%s' is not writable; using fallback '%s'.",
+                    database_file,
+                    fallback_database,
+                )
+                database_file = fallback_database
+            else:
+                LOGGER.warning(
+                    "Database location '%s' is not writable and no fallback is available.",
+                    database_file,
+                )
+
         return cls(storage_root=storage_root, database_file=database_file, assets_root=assets_root)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import app.config as config_module
+from app.config import AppConfig
+
+
+def test_assets_root_falls_back_when_preferred_is_unusable(tmp_path: Path) -> None:
+    storage = tmp_path / "storage"
+    storage.mkdir()
+
+    preferred_assets = tmp_path / "assets"
+    preferred_assets.write_text("not a directory", encoding="utf-8")
+
+    config = AppConfig.from_mapping(
+        {
+            "storage_root": "storage",
+            "database_file": "storage/lectures.db",
+            "assets_root": "assets",
+        },
+        base_path=tmp_path,
+    )
+
+    expected_fallback = (storage / "_assets").resolve()
+    assert config.assets_root == expected_fallback
+    assert expected_fallback.exists()
+    assert expected_fallback.is_dir()
+
+
+def test_storage_root_falls_back_when_preferred_is_unusable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(config_module.Path, "home", lambda: home_dir)
+
+    preferred_storage = tmp_path / "storage"
+    preferred_storage.write_text("not a directory", encoding="utf-8")
+
+    preferred_assets = tmp_path / "assets"
+    preferred_assets.write_text("not a directory", encoding="utf-8")
+
+    config = AppConfig.from_mapping(
+        {
+            "storage_root": "storage",
+            "database_file": "storage/lectures.db",
+            "assets_root": "assets",
+        },
+        base_path=tmp_path,
+    )
+
+    expected_storage = (home_dir / ".lecture_tools" / "storage").resolve()
+    expected_database = (expected_storage / "lectures.db").resolve()
+    expected_assets = (expected_storage / "_assets").resolve()
+
+    assert config.storage_root == expected_storage
+    assert config.database_file == expected_database
+    assert config.assets_root == expected_assets
+    assert expected_storage.exists()
+    assert expected_assets.exists()


### PR DESCRIPTION
## Summary
- add a helper to select writable directories with fallbacks when the preferred storage location is not accessible
- fall back to a user-writable storage directory and relocate the database/assets directories when the defaults cannot be used
- extend the configuration tests to cover storage and database fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9cf7c0f2483309d3198a47ad03324