### PR TITLE
Harden storage directory selection for unwritable environments

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+import app.config as config_module
+from app.bootstrap import BootstrapError, Bootstrapper
+from app.config import AppConfig
+
+
+def test_bootstrapper_raises_when_storage_directory_unwritable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    storage_root = tmp_path / "storage"
+    assets_root = tmp_path / "assets"
+    database_file = storage_root / "lectures.db"
+
+    config = AppConfig(
+        storage_root=storage_root,
+        database_file=database_file,
+        assets_root=assets_root,
+    )
+
+    original_ensure = config_module._ensure_writable_directory
+
+    def fake_ensure(path: Path) -> bool:
+        if path.resolve() == storage_root.resolve():
+            return False
+        return original_ensure(path)
+
+    monkeypatch.setattr(config_module, "_ensure_writable_directory", fake_ensure)
+
+    bootstrapper = Bootstrapper(config)
+
+    with pytest.raises(BootstrapError) as excinfo:
+        bootstrapper.initialize()
+
+    assert "storage" in str(excinfo.value).lower()
+
+


### PR DESCRIPTION
## Summary
- add a temp-directory storage fallback and ignore duplicate fallback candidates when selecting writable locations
- ensure bootstrap validates storage, assets, and archive directories are writable before continuing so permission issues surface early
- extend the configuration test suite and add a bootstrap regression test for unwritable directories

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9db2b492483309c9f1ea560eddb13