### PR TITLE
Fix storage path resolution and proxy prefix inference

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -551,7 +551,7 @@ def _safe_preview_for_path(storage_root: Path, relative_path: Optional[str]) -> 
 
 
 def _resolve_storage_path(_storage_root: Path, relative_path: str) -> Path:
-    root_path = _require_storage_root().resolve()
+    root_path = _storage_root.resolve()
     candidate = Path(relative_path)
     if not candidate.is_absolute():
         candidate = (root_path / candidate).resolve()
@@ -787,13 +787,14 @@ def _infer_prefix_from_path(value: Any) -> Optional[str]:
         "/docs",
         "/openapi.json",
     )
+    reserved_prefixes: Tuple[str, ...] = ("/api", "/storage", "/static")
     for marker in markers:
         index = path.find(marker)
         if index <= 0:
             continue
         prefix = path[:index]
         prefix = prefix.rstrip("/")
-        if prefix:
+        if prefix and prefix not in reserved_prefixes:
             return prefix
 
     return None


### PR DESCRIPTION
## Summary
- resolve storage paths using the provided storage root rather than calling an unavailable helper
- ensure forwarded-prefix inference ignores built-in API and storage routes so base paths still work

## Testing
- pytest tests/test_web_api.py::test_static_storage_respects_root_path -q
- pytest tests/test_web_api.py::test_storage_endpoints_recover_missing_root -q

------
https://chatgpt.com/codex/tasks/task_e_68d9eb20dba883309267416ecfe1ee29