### PR TITLE
Normalize storage-relative paths for cloud asset fetching

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -1571,8 +1571,19 @@ def _safe_preview_for_path(storage_root: Path, relative_path: Optional[str]) -> 
     }
 
 
+def _normalize_storage_relative_path(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        return cleaned
+    cleaned = cleaned.replace("\\", "/")
+    while cleaned.startswith("/"):
+        cleaned = cleaned[1:]
+    return cleaned
+
+
 def _resolve_storage_path(_storage_root: Path, relative_path: str) -> Path:
     root_path = _storage_root.resolve()
+    relative_path = _normalize_storage_relative_path(relative_path)
     candidate = Path(relative_path)
     if not candidate.is_absolute():
         candidate = (root_path / candidate).resolve()
@@ -2765,6 +2776,9 @@ def create_app(
         return candidate if candidate.exists() else None
 
     async def _fetch_cloud_asset(relative: Optional[str]) -> Optional[Path]:
+        if not relative:
+            return None
+        relative = _normalize_storage_relative_path(relative)
         if not relative:
             return None
         settings = _load_ui_settings()


### PR DESCRIPTION
### Motivation
- Cloud asset downloads could fail when stored paths include backslashes or leading slashes because `_resolve_storage_path` treated them as absolute or outside the storage root, preventing local resolution and remote fetch.
- Ensure paths and generated cloud URLs match stored asset locations across platforms (Windows vs Unix) so downloadable assets can be fetched reliably.

### Description
- Add `
def _normalize_storage_relative_path(value: str) -> str
` to canonicalize storage-relative paths by trimming, converting backslashes to forward slashes, and stripping leading slashes.
- Apply normalization inside `
_resolve_storage_path
` before creating the `Path` so relative inputs are interpreted consistently.
- Apply normalization at the start of `
_fetch_cloud_asset
` and guard empty results so remote URL generation and destination resolution align with stored paths.
- Changes made in `app/web/server.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984fb7ec14883309a08e8928c03422f)