### PR TITLE
Enhance bulk download UI and add combined TXT/MD export

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -1901,6 +1901,7 @@ class BulkDownloadItem(BaseModel):
 
 class BulkDownloadRequest(BaseModel):
     items: List[BulkDownloadItem] = Field(default_factory=list)
+    combine_text_assets: bool = False
 
 
 class LectureStorageSummary(BaseModel):
@@ -6812,6 +6813,7 @@ def create_app(
     @app.post("/api/download/bulk")
     async def download_bulk_assets(payload: BulkDownloadRequest) -> Dict[str, Any]:
         normalized: Dict[int, Set[str]] = {}
+        combine_text_assets = bool(payload.combine_text_assets)
         raw_items = payload.items if isinstance(payload.items, list) else []
         for item in raw_items:
             lecture_id = int(getattr(item, "lecture_id", 0))
@@ -6841,6 +6843,7 @@ def create_app(
         archive_path = archive_root / filename
         file_count = 0
         written: Set[str] = set()
+        text_entries: List[Dict[str, Any]] = []
 
         try:
             with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
@@ -6885,6 +6888,80 @@ def create_app(
                         bundle.write(source, arcname)
                         written.add(arcname)
                         file_count += 1
+                        if combine_text_assets and asset_key in {"txt", "md"}:
+                            text_entries.append(
+                                {
+                                    "source": source,
+                                    "asset_key": asset_key,
+                                    "class_name": class_record.name if class_record else "",
+                                    "class_id": class_record.id if class_record else None,
+                                    "module_name": module.name if module else "",
+                                    "module_id": module.id if module else None,
+                                    "lecture_name": lecture.name,
+                                    "lecture_id": lecture.id,
+                                    "class_position": (
+                                        class_record.position
+                                        if class_record and class_record.position is not None
+                                        else 0
+                                    ),
+                                    "module_position": (
+                                        module.position
+                                        if module and module.position is not None
+                                        else 0
+                                    ),
+                                    "lecture_position": (
+                                        lecture.position if lecture.position is not None else 0
+                                    ),
+                                }
+                            )
+
+                if combine_text_assets and text_entries:
+                    text_entries.sort(
+                        key=lambda entry: (
+                            int(entry.get("class_position", 0)),
+                            str(entry.get("class_name", "")).lower(),
+                            int(entry.get("module_position", 0)),
+                            str(entry.get("module_name", "")).lower(),
+                            int(entry.get("lecture_position", 0)),
+                            str(entry.get("lecture_name", "")).lower(),
+                            0 if entry.get("asset_key") == "txt" else 1,
+                        )
+                    )
+
+                    combined_lines: List[str] = [
+                        "# Lecture Tools Combined Text Export",
+                        "",
+                    ]
+                    for index, entry in enumerate(text_entries, start=1):
+                        class_name = entry.get("class_name") or f"Class {entry.get('class_id') or '?'}"
+                        module_name = entry.get("module_name") or f"Module {entry.get('module_id') or '?'}"
+                        lecture_name = entry.get("lecture_name") or f"Lecture {entry.get('lecture_id') or '?'}"
+                        asset_label = "Transcript (TXT)" if entry.get("asset_key") == "txt" else "Notes (MD)"
+                        source_name = entry.get("source").name if entry.get("source") else "unknown"
+                        combined_lines.extend(
+                            [
+                                f"\n\n========== ITEM {index:04d} ==========",
+                                f"Class: {class_name}",
+                                f"Module: {module_name}",
+                                f"Lecture: {lecture_name}",
+                                f"Asset: {asset_label}",
+                                f"Source: {source_name}",
+                                "----------------------------------------",
+                            ]
+                        )
+                        source_path = entry.get("source")
+                        try:
+                            content = Path(source_path).read_text(encoding="utf-8")
+                        except UnicodeDecodeError:
+                            content = Path(source_path).read_text(encoding="utf-8", errors="replace")
+                        except OSError:
+                            content = ""
+                        combined_lines.append(content.rstrip("\n"))
+
+                    combined_name = build_timestamped_name("combined-text-assets", extension="txt")
+                    combined_payload = "\n".join(combined_lines).rstrip("\n") + "\n"
+                    bundle.writestr((Path("lectures") / combined_name).as_posix(), combined_payload)
+                    file_count += 1
         except OSError as error:
             with contextlib.suppress(OSError):
                 archive_path.unlink()

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -6163,9 +6163,19 @@
             <button id="bulk-download-clear" type="button" class="dialog-button" data-i18n="tasks.bulkDownload.clear">
               Clear selections
             </button>
+            <button id="bulk-download-select-all-txt" type="button" class="dialog-button" data-i18n="tasks.bulkDownload.selectAllTxt">
+              Select all TXT
+            </button>
+            <button id="bulk-download-select-all-txt-md" type="button" class="dialog-button" data-i18n="tasks.bulkDownload.selectAllTxtMd">
+              Select all TXT + MD
+            </button>
           </div>
         </div>
         <div id="bulk-download-content" class="bulk-process-content"></div>
+        <label class="field-inline" for="bulk-download-combine-text">
+          <input id="bulk-download-combine-text" type="checkbox" />
+          <span data-i18n="tasks.bulkDownload.combineText">Combine selected TXT/MD assets into one ordered TXT file</span>
+        </label>
         <div id="bulk-download-empty" class="bulk-process-empty hidden" data-i18n="tasks.bulkDownload.empty">
           No assets available.
         </div>
@@ -6326,19 +6336,28 @@
                 subtitle: 'Select lectures and asset formats to download.',
                 selectAll: 'Select all',
                 clear: 'Clear selections',
+                selectAllTxt: 'Select all TXT',
+                selectAllTxtMd: 'Select all TXT + MD',
                 empty: 'No downloadable assets available.',
                 cancel: 'Cancel',
                 submit: 'Prepare download',
+                combineText: 'Combine selected TXT/MD assets into one ordered TXT file',
                 summaryEmpty: 'No assets selected.',
                 summarySelected: '{{count}} {{assetWord}} selected.',
                 summaryBreakdown:
                   'Audio: {{audio}} • Transcript (TXT): {{txt}} • Slides (PDF): {{pdf}} • Notes (MD): {{md}} • Bundles (ZIP): {{zip}}.',
+                combineEnabled: 'Combined TXT/MD export enabled.',
                 assetSingular: 'asset',
                 assetPlural: 'assets',
                 status: {
                   available: 'Available',
                   selected: 'Selected',
                   unavailable: 'Missing',
+                },
+                classActions: {
+                  all: 'All assets in class',
+                  txt: 'TXT in class',
+                  txtMd: 'TXT + MD in class',
                 },
                 assets: {
                   audio: 'Audio',
@@ -7031,18 +7050,27 @@
                 subtitle: '选择要下载的讲座和资源格式。',
                 selectAll: '全选',
                 clear: '清除选择',
+                selectAllTxt: 'Select all TXT',
+                selectAllTxtMd: 'Select all TXT + MD',
                 empty: '没有可下载的资源。',
                 cancel: '取消',
                 submit: '准备下载',
+                combineText: 'Combine selected TXT/MD assets into one ordered TXT file',
                 summaryEmpty: '未选择任何资源。',
                 summarySelected: '已选择 {{count}} 个{{assetWord}}。',
                 summaryBreakdown: '音频：{{audio}} • 文本 (TXT)：{{txt}} • 幻灯片 (PDF)：{{pdf}} • 笔记 (MD)：{{md}} • 打包 (ZIP)：{{zip}}。',
+                combineEnabled: 'Combined TXT/MD export enabled.',
                 assetSingular: '资源',
                 assetPlural: '资源',
                 status: {
                   available: '可用',
                   selected: '已选择',
                   unavailable: '缺失',
+                },
+                classActions: {
+                  all: 'All assets in class',
+                  txt: 'TXT in class',
+                  txtMd: 'TXT + MD in class',
                 },
                 assets: {
                   audio: '音频',
@@ -7685,6 +7713,8 @@
                 subtitle: 'Selecciona clases y recursos para añadir a la cola de procesamiento.',
                 selectAll: 'Seleccionar todo',
                 clear: 'Limpiar selección',
+                selectAllTxt: 'Select all TXT',
+                selectAllTxtMd: 'Select all TXT + MD',
                 empty: 'No hay clases disponibles para procesar.',
                 cancel: 'Cancelar',
                 submit: 'Añadir a la cola',
@@ -7726,19 +7756,28 @@
                 subtitle: 'Selecciona clases y formatos para descargar.',
                 selectAll: 'Seleccionar todo',
                 clear: 'Limpiar selección',
+                selectAllTxt: 'Select all TXT',
+                selectAllTxtMd: 'Select all TXT + MD',
                 empty: 'No hay recursos disponibles para descargar.',
                 cancel: 'Cancelar',
                 submit: 'Preparar descarga',
+                combineText: 'Combine selected TXT/MD assets into one ordered TXT file',
                 summaryEmpty: 'No hay recursos seleccionados.',
                 summarySelected: '{{count}} {{assetWord}} seleccionados.',
                 summaryBreakdown:
                   'Audio: {{audio}} • Transcripción (TXT): {{txt}} • Diapositivas (PDF): {{pdf}} • Notas (MD): {{md}} • Paquetes (ZIP): {{zip}}.',
+                combineEnabled: 'Combined TXT/MD export enabled.',
                 assetSingular: 'recurso',
                 assetPlural: 'recursos',
                 status: {
                   available: 'Disponible',
                   selected: 'Seleccionado',
                   unavailable: 'No disponible',
+                },
+                classActions: {
+                  all: 'All assets in class',
+                  txt: 'TXT in class',
+                  txtMd: 'TXT + MD in class',
                 },
                 assets: {
                   audio: 'Audio',
@@ -8440,9 +8479,12 @@
                 subtitle: 'Sélectionnez les cours et formats à télécharger.',
                 selectAll: 'Tout sélectionner',
                 clear: 'Effacer la sélection',
+                selectAllTxt: 'Select all TXT',
+                selectAllTxtMd: 'Select all TXT + MD',
                 empty: 'Aucune ressource disponible pour le téléchargement.',
                 cancel: 'Annuler',
                 submit: 'Préparer le téléchargement',
+                combineText: 'Combine selected TXT/MD assets into one ordered TXT file',
                 summaryEmpty: 'Aucune ressource sélectionnée.',
                 summarySelected: '{{count}} {{assetWord}} sélectionné(s).',
                 summaryBreakdown:
@@ -8453,6 +8495,11 @@
                   available: 'Disponible',
                   selected: 'Sélectionné',
                   unavailable: 'Manquant',
+                },
+                classActions: {
+                  all: 'All assets in class',
+                  txt: 'TXT in class',
+                  txtMd: 'TXT + MD in class',
                 },
                 assets: {
                   audio: 'Audio',
@@ -9555,6 +9602,7 @@
             expandedModules: new Map(),
             availableCount: 0,
             lectureCount: 0,
+            combineTextAssets: false,
           },
           systemUpdate: {
             running: false,
@@ -9936,8 +9984,11 @@
             summary: document.getElementById('bulk-download-summary'),
             selectAll: document.getElementById('bulk-download-select-all'),
             clear: document.getElementById('bulk-download-clear'),
+            selectAllTxt: document.getElementById('bulk-download-select-all-txt'),
+            selectAllTxtMd: document.getElementById('bulk-download-select-all-txt-md'),
             cancel: document.getElementById('bulk-download-cancel'),
             submit: document.getElementById('bulk-download-submit'),
+            combineText: document.getElementById('bulk-download-combine-text'),
           },
         };
 
@@ -12554,6 +12605,41 @@
           return `${lectureId}:${assetKey}`;
         }
 
+        function selectBulkDownloadWhere(predicate) {
+          state.bulkDownload.meta.forEach((meta, key) => {
+            if (!meta || !meta.available) {
+              state.bulkDownload.selections.delete(key);
+              return;
+            }
+            if (typeof predicate === 'function' && predicate(meta)) {
+              state.bulkDownload.selections.set(key, true);
+            }
+          });
+          refreshBulkDownloadCheckboxes();
+          updateBulkDownloadSummary();
+        }
+
+        function handleBulkDownloadQuickSelect(assetKeys) {
+          const target = new Set(Array.isArray(assetKeys) ? assetKeys : []);
+          if (!target.size) {
+            return;
+          }
+          selectBulkDownloadWhere((meta) => target.has(meta.assetKey));
+        }
+
+        function selectBulkDownloadForClass(classId, assetKeys = null) {
+          const target = assetKeys ? new Set(assetKeys) : null;
+          selectBulkDownloadWhere((meta) => {
+            if (meta.classId !== classId) {
+              return false;
+            }
+            if (!target) {
+              return true;
+            }
+            return target.has(meta.assetKey);
+          });
+        }
+
         function collectBulkDownloadMeta() {
           const meta = state.bulkDownload.meta;
           meta.clear();
@@ -12696,6 +12782,44 @@
               lectureWord,
             });
             classSummary.appendChild(classMeta);
+
+            const classActions = document.createElement('div');
+            classActions.className = 'asset-actions';
+
+            const selectClassAll = document.createElement('button');
+            selectClassAll.type = 'button';
+            selectClassAll.className = 'secondary';
+            selectClassAll.textContent = t('tasks.bulkDownload.classActions.all');
+            selectClassAll.addEventListener('click', (event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              selectBulkDownloadForClass(classId);
+            });
+            classActions.appendChild(selectClassAll);
+
+            const selectClassTxt = document.createElement('button');
+            selectClassTxt.type = 'button';
+            selectClassTxt.className = 'secondary';
+            selectClassTxt.textContent = t('tasks.bulkDownload.classActions.txt');
+            selectClassTxt.addEventListener('click', (event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              selectBulkDownloadForClass(classId, ['txt']);
+            });
+            classActions.appendChild(selectClassTxt);
+
+            const selectClassTxtMd = document.createElement('button');
+            selectClassTxtMd.type = 'button';
+            selectClassTxtMd.className = 'secondary';
+            selectClassTxtMd.textContent = t('tasks.bulkDownload.classActions.txtMd');
+            selectClassTxtMd.addEventListener('click', (event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              selectBulkDownloadForClass(classId, ['txt', 'md']);
+            });
+            classActions.appendChild(selectClassTxtMd);
+
+            classSummary.appendChild(classActions);
 
             classDetails.appendChild(classSummary);
 
@@ -12913,6 +13037,11 @@
             });
             summary.appendChild(totalLine);
             summary.appendChild(breakdownLine);
+            if (state.bulkDownload.combineTextAssets) {
+              const combineLine = document.createElement('p');
+              combineLine.textContent = t('tasks.bulkDownload.combineEnabled');
+              summary.appendChild(combineLine);
+            }
           }
 
           if (selectAllButton) {
@@ -12920,6 +13049,12 @@
           }
           if (clearButton) {
             clearButton.disabled = state.bulkDownload.selections.size === 0;
+          }
+          if (dom.bulkDownloadDialog?.selectAllTxt) {
+            dom.bulkDownloadDialog.selectAllTxt.disabled = state.bulkDownload.availableCount === 0;
+          }
+          if (dom.bulkDownloadDialog?.selectAllTxtMd) {
+            dom.bulkDownloadDialog.selectAllTxtMd.disabled = state.bulkDownload.availableCount === 0;
           }
           if (submitButton) {
             submitButton.disabled = state.bulkDownload.selections.size === 0;
@@ -13019,7 +13154,7 @@
             const response = await request('/api/download/bulk', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ items }),
+              body: JSON.stringify({ items, combine_text_assets: state.bulkDownload.combineTextAssets }),
             });
             const archive = response?.archive;
             if (!archive || !archive.path) {
@@ -13075,6 +13210,10 @@
           bulkDownloadPreviousFocus =
             document.activeElement instanceof HTMLElement ? document.activeElement : null;
 
+          if (dom.bulkDownloadDialog.combineText) {
+            dom.bulkDownloadDialog.combineText.checked = state.bulkDownload.combineTextAssets;
+          }
+
           const focusTargets = [
             dom.bulkDownloadDialog.selectAll,
             dom.bulkDownloadDialog.clear,
@@ -13091,10 +13230,27 @@
             selectAllBulkDownload();
           }
 
+          function handleCombineTextChange(event) {
+            state.bulkDownload.combineTextAssets = Boolean(event?.target?.checked);
+            updateBulkDownloadSummary();
+          }
+
           function handleClear(event) {
             event?.preventDefault?.();
             setBulkDownloadStatus('');
             clearBulkDownloadSelections();
+          }
+
+          function handleSelectAllTxt(event) {
+            event?.preventDefault?.();
+            setBulkDownloadStatus('');
+            handleBulkDownloadQuickSelect(['txt']);
+          }
+
+          function handleSelectAllTxtMd(event) {
+            event?.preventDefault?.();
+            setBulkDownloadStatus('');
+            handleBulkDownloadQuickSelect(['txt', 'md']);
           }
 
           function handleCancel(event) {
@@ -13142,8 +13298,17 @@
           if (dom.bulkDownloadDialog.clear) {
             dom.bulkDownloadDialog.clear.addEventListener('click', handleClear);
           }
+          if (dom.bulkDownloadDialog.selectAllTxt) {
+            dom.bulkDownloadDialog.selectAllTxt.addEventListener('click', handleSelectAllTxt);
+          }
+          if (dom.bulkDownloadDialog.selectAllTxtMd) {
+            dom.bulkDownloadDialog.selectAllTxtMd.addEventListener('click', handleSelectAllTxtMd);
+          }
           if (dom.bulkDownloadDialog.cancel) {
             dom.bulkDownloadDialog.cancel.addEventListener('click', handleCancel);
+          }
+          if (dom.bulkDownloadDialog.combineText) {
+            dom.bulkDownloadDialog.combineText.addEventListener('change', handleCombineTextChange);
           }
           if (dom.bulkDownloadDialog.backdrop) {
             dom.bulkDownloadDialog.backdrop.addEventListener('click', handleBackdrop);
@@ -13163,8 +13328,17 @@
             if (dom.bulkDownloadDialog.clear) {
               dom.bulkDownloadDialog.clear.removeEventListener('click', handleClear);
             }
+            if (dom.bulkDownloadDialog.selectAllTxt) {
+              dom.bulkDownloadDialog.selectAllTxt.removeEventListener('click', handleSelectAllTxt);
+            }
+            if (dom.bulkDownloadDialog.selectAllTxtMd) {
+              dom.bulkDownloadDialog.selectAllTxtMd.removeEventListener('click', handleSelectAllTxtMd);
+            }
             if (dom.bulkDownloadDialog.cancel) {
               dom.bulkDownloadDialog.cancel.removeEventListener('click', handleCancel);
+            }
+            if (dom.bulkDownloadDialog.combineText) {
+              dom.bulkDownloadDialog.combineText.removeEventListener('change', handleCombineTextChange);
             }
             if (dom.bulkDownloadDialog.backdrop) {
               dom.bulkDownloadDialog.backdrop.removeEventListener('click', handleBackdrop);

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -402,6 +402,41 @@ def test_bulk_download_endpoint_prepares_archive(temp_config):
         assert archive.get("count") == 5
 
 
+
+
+def test_bulk_download_can_combine_text_assets(temp_config):
+    repository, lecture_id, _module_id = _create_sample_data(temp_config)
+    app = create_app(repository, config=temp_config)
+    client = TestClient(app)
+
+    payload = {
+        "items": [
+            {
+                "lecture_id": lecture_id,
+                "assets": ["txt", "md"],
+            }
+        ],
+        "combine_text_assets": True,
+    }
+
+    response = client.post("/api/download/bulk", json=payload)
+    assert response.status_code == 200
+    archive = response.json().get("archive") or {}
+    archive_path = temp_config.storage_root / archive.get("path", "")
+    assert archive_path.exists()
+
+    with zipfile.ZipFile(archive_path, "r") as bundle:
+        names = set(bundle.namelist())
+        combined_files = [name for name in names if name.startswith("lectures/combined-text-assets") and name.endswith(".txt")]
+        assert len(combined_files) == 1
+        combined_content = bundle.read(combined_files[0]).decode("utf-8")
+        assert "Class: Astronomy" in combined_content
+        assert "Module: Stellar Physics" in combined_content
+        assert "Lecture: Stellar Evolution" in combined_content
+        assert "Line one" in combined_content
+        assert "# Notes" in combined_content
+        assert archive.get("count") == 3
+
 def test_bulk_download_requires_valid_selection(temp_config):
     repository, lecture_id, _module_id = _create_sample_data(temp_config)
     app = create_app(repository, config=temp_config)


### PR DESCRIPTION
### Motivation

- Improve the bulk-download workflow so users can make richer selections (per-class quick-selects and quick buttons) and optionally produce a single combined text export of selected TXT/MD assets while preserving lecture ordering and structure.

### Description

- Add a new boolean field `combine_text_assets` to the `BulkDownloadRequest` Pydantic model and wire it into the `/api/download/bulk` handler to enable combined exports when requested.
- Implement server-side logic in `app/web/server.py` to collect selected TXT/MD files, sort them by class/module/lecture positions and names (and prefer `txt` before `md`), and produce a single combined TXT file named with `build_timestamped_name("combined-text-assets", extension="txt")` injected into the ZIP archive with descriptive headers for each item.
- Extend the web UI in `app/web/templates/index.html` to add a `bulk-download-combine-text` checkbox, quick-select buttons (`bulk-download-select-all-txt`, `bulk-download-select-all-txt-md`), and per-class quick action buttons (All / TXT / TXT+MD); add client-side state `state.bulkDownload.combineTextAssets` and include `combine_text_assets` in the POST body to `/api/download/bulk` when preparing the archive.
- Add a unit test `test_bulk_download_can_combine_text_assets` in `tests/test_web_api.py` verifying the combined TXT is produced inside the archive and contains expected class/module/lecture headers and content.

### Testing

- Ran `pytest` for the bulk-download related tests: `test_bulk_download_endpoint_prepares_archive`, `test_bulk_download_can_combine_text_assets`, and `test_bulk_download_requires_valid_selection`, and they all passed (`... [100%]`).
- Confirmed the new API handler compiles by running `python -m compileall -q app/web/server.py` without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0cf403a408330a42ee2ca33d0b987)