### PR TITLE
Add Whisper benchmark & uninstall features and harden cloud upload reliability

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -312,6 +312,7 @@ _TEMPLATE_PATH = Path(__file__).parent / "templates" / "index.html"
 _PREVIEW_LIMIT = 1200
 _WHISPER_MODEL_OPTIONS: Tuple[str, ...] = ("tiny", "base", "small", "medium", "large", "gpu")
 _WHISPER_MODEL_SET = set(_WHISPER_MODEL_OPTIONS)
+_WHISPER_BENCHMARK_MODELS: Tuple[str, ...] = ("tiny", "base", "small", "medium", "large")
 _SLIDE_DPI_OPTIONS: Tuple[int, ...] = (150, 200, 300, 400, 600)
 _SLIDE_DPI_SET = set(_SLIDE_DPI_OPTIONS)
 _LANGUAGE_OPTIONS: Tuple[str, ...] = ("en", "zh", "es", "fr")
@@ -350,6 +351,13 @@ except ValueError:
     _MAX_UPLOAD_BYTES = _DEFAULT_MAX_UPLOAD_BYTES
 
 _DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024
+_WHISPER_BENCHMARK_AUDIO_URL = (
+    "https://archive.org/download/horse_and_pony_1906_librivox/horseandpony_01_sewell_64kb.mp3"
+)
+_WHISPER_BENCHMARK_AUDIO_NAME = "public_domain_sample.mp3"
+_WHISPER_BENCHMARK_AUDIO_TRANSCRIPT_HINT = (
+    "Opening chapter of Anna Sewell's Horse and Pony from LibriVox (public domain)."
+)
 
 def get_max_upload_bytes() -> int:
     """Return the configured maximum upload size in bytes."""
@@ -2931,26 +2939,24 @@ def create_app(
             )
         url = f"{base_url}/api/lectures/{lecture_id}/assets/{asset_type}"
         content_type = _content_type_for_asset(file_path)
-        try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
-                with file_path.open("rb") as handle:
-                    response = await client.post(
-                        url,
-                        files={"file": (file_path.name, handle, content_type)},
-                    )
-            if response.status_code != status.HTTP_200_OK:
+        last_error: Optional[str] = None
+        for attempt in range(1, 4):
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    with file_path.open("rb") as handle:
+                        response = await client.post(
+                            url,
+                            files={"file": (file_path.name, handle, content_type)},
+                        )
+                if response.status_code == status.HTTP_200_OK:
+                    return
                 detail = response.text.strip() or response.reason_phrase
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"Cloud upload failed ({response.status_code}): {detail}",
-                )
-        except HTTPException:
-            raise
-        except Exception as error:  # pragma: no cover - network failures
-            raise HTTPException(
-                status_code=502,
-                detail=f"Cloud upload failed: {error}",
-            ) from error
+                last_error = f"Cloud upload failed ({response.status_code}): {detail}"
+            except Exception as error:  # pragma: no cover - network failures
+                last_error = f"Cloud upload failed: {error}"
+            if attempt < 3:
+                await asyncio.sleep(0.5 * attempt)
+        raise HTTPException(status_code=502, detail=last_error or "Cloud upload failed")
 
     async def _sync_cloud_processing_assets(
         lecture_id: int,
@@ -2979,6 +2985,46 @@ def create_app(
                     detail=f"Notes path is outside storage root: {error}",
                 ) from error
             await _upload_cloud_asset(lecture_id, "notes", notes_path)
+
+    async def _ensure_whisper_benchmark_audio() -> Path:
+        audio_dir = config.assets_root / "benchmarks"
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        audio_path = audio_dir / _WHISPER_BENCHMARK_AUDIO_NAME
+        if audio_path.exists() and audio_path.stat().st_size > 0:
+            return audio_path
+        temp_path = audio_path.with_suffix(f"{audio_path.suffix}.download-{uuid.uuid4().hex}")
+        async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+            response = await client.get(_WHISPER_BENCHMARK_AUDIO_URL)
+            response.raise_for_status()
+            temp_path.write_bytes(response.content)
+        if temp_path.stat().st_size == 0:
+            temp_path.unlink(missing_ok=True)
+            raise HTTPException(status_code=502, detail="Benchmark audio download returned empty data")
+        temp_path.replace(audio_path)
+        return audio_path
+
+    def _whisper_model_directory() -> Path:
+        return config.assets_root / "models"
+
+    def _model_files_for_name(model_name: str) -> List[Path]:
+        model_dir = _whisper_model_directory()
+        if not model_dir.exists():
+            return []
+        normal = model_name.strip().lower()
+        prefixes = [
+            f"ggml-{normal}",
+            f"ggml-{normal}.en",
+            f"{normal}",
+            f"{normal}.en",
+        ]
+        matches: List[Path] = []
+        for entry in model_dir.iterdir():
+            if not entry.is_file():
+                continue
+            stem = entry.stem.lower()
+            if any(stem == prefix or stem.startswith(f"{prefix}.") for prefix in prefixes):
+                matches.append(entry)
+        return matches
 
     def _relative_existing_path(
         candidate: Optional[Path], *, root: Optional[Path] = None
@@ -4918,6 +4964,83 @@ def create_app(
         state = _record_gpu_probe(probe)
         _log_event("GPU probe completed", supported=state.get("supported"))
         return {"status": state}
+
+    @app.post("/api/settings/whisper/benchmark")
+    async def benchmark_whisper_models() -> Dict[str, Any]:
+        if FasterWhisperTranscription is None:
+            raise HTTPException(status_code=503, detail="Transcription backend is unavailable.")
+        sample_audio = await _ensure_whisper_benchmark_audio()
+        benchmark_root = config.assets_root / "benchmarks"
+        benchmark_root.mkdir(parents=True, exist_ok=True)
+        results: List[Dict[str, Any]] = []
+
+        for model_name in _WHISPER_BENCHMARK_MODELS:
+            started = time.perf_counter()
+            output_dir = benchmark_root / f"run-{model_name}-{int(time.time())}"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                engine = FasterWhisperTranscription(
+                    model_name,
+                    download_root=config.assets_root,
+                    compute_type=_DEFAULT_UI_SETTINGS.whisper_compute_type,
+                    beam_size=_DEFAULT_UI_SETTINGS.whisper_beam_size,
+                )
+                result = await asyncio.to_thread(engine.transcribe, sample_audio, output_dir)
+                duration = time.perf_counter() - started
+                preview = result.transcript_path.read_text(encoding="utf-8")[:220].strip()
+                results.append(
+                    {
+                        "model": model_name,
+                        "ok": True,
+                        "seconds": round(duration, 3),
+                        "transcript_chars": len(result.text),
+                        "preview": preview,
+                    }
+                )
+            except Exception as error:  # noqa: BLE001 - benchmark must continue
+                duration = time.perf_counter() - started
+                results.append(
+                    {
+                        "model": model_name,
+                        "ok": False,
+                        "seconds": round(duration, 3),
+                        "error": str(error),
+                    }
+                )
+        successful = [row for row in results if row.get("ok")]
+        recommended = min(successful, key=lambda row: float(row.get("seconds") or 0.0))["model"] if successful else None
+        return {
+            "sample": {
+                "path": sample_audio.relative_to(config.assets_root).as_posix(),
+                "source": _WHISPER_BENCHMARK_AUDIO_URL,
+                "description": _WHISPER_BENCHMARK_AUDIO_TRANSCRIPT_HINT,
+            },
+            "recommended_model": recommended,
+            "results": results,
+        }
+
+    @app.delete("/api/settings/whisper-models/{model_name}")
+    async def uninstall_whisper_model(model_name: str) -> Dict[str, Any]:
+        normalized = (model_name or "").strip().lower()
+        if not normalized:
+            raise HTTPException(status_code=400, detail="Model name is required")
+        if normalized == "gpu":
+            targets = [
+                config.assets_root / "models" / "ggml-medium.en.bin",
+            ]
+        else:
+            targets = _model_files_for_name(normalized)
+        removed: List[str] = []
+        missing: List[str] = []
+        for path in targets:
+            if path.exists():
+                path.unlink(missing_ok=True)
+                removed.append(path.relative_to(config.assets_root).as_posix())
+            else:
+                missing.append(path.name)
+        if not removed and normalized != "gpu":
+            raise HTTPException(status_code=404, detail=f"No local files found for model '{normalized}'")
+        return {"model": normalized, "removed": removed, "missing": missing}
 
     @app.get("/api/settings")
     async def get_settings() -> Dict[str, Any]:

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -5484,6 +5484,33 @@
                     <span data-i18n="settings.whisper.gpu.test">Test support</span>
                   </button>
                 </div>
+                <div class="field-inline gpu-support">
+                  <div class="gpu-support-info">
+                    <label data-i18n="settings.whisper.benchmark.label">Model benchmark</label>
+                    <p id="settings-whisper-benchmark-status" data-i18n="settings.whisper.benchmark.status">
+                      Run benchmark to compare models on the bundled public-domain sample.
+                    </p>
+                  </div>
+                  <button id="settings-whisper-benchmark-run" type="button" class="secondary">
+                    <span data-i18n="settings.whisper.benchmark.run">Run benchmark</span>
+                  </button>
+                </div>
+                <div class="field-inline">
+                  <label for="settings-whisper-model-uninstall" data-i18n="settings.whisper.uninstall.label">
+                    Uninstall local model
+                  </label>
+                  <select id="settings-whisper-model-uninstall">
+                    <option value="tiny">tiny</option>
+                    <option value="base">base</option>
+                    <option value="small">small</option>
+                    <option value="medium">medium</option>
+                    <option value="large">large</option>
+                    <option value="gpu">gpu</option>
+                  </select>
+                  <button id="settings-whisper-model-uninstall-run" type="button" class="secondary">
+                    <span data-i18n="settings.whisper.uninstall.run">Uninstall</span>
+                  </button>
+                </div>
               </fieldset>
               <fieldset>
                 <legend data-i18n="settings.cloudConnection.legend">Cloud connection</legend>
@@ -6476,6 +6503,15 @@
                   status: 'GPU acceleration not tested.',
                   test: 'Test support',
                   retry: 'Re-run test',
+                },
+                benchmark: {
+                  label: 'Model benchmark',
+                  status: 'Run benchmark to compare models on the bundled public-domain sample.',
+                  run: 'Run benchmark',
+                },
+                uninstall: {
+                  label: 'Uninstall local model',
+                  run: 'Uninstall',
                 },
               },
               cloudConnection: {
@@ -9773,6 +9809,10 @@
           settingsWhisperBeam: document.getElementById('settings-whisper-beam'),
           settingsWhisperGpuStatus: document.getElementById('settings-whisper-gpu-status'),
           settingsWhisperGpuTest: document.getElementById('settings-whisper-gpu-test'),
+          settingsWhisperBenchmarkStatus: document.getElementById('settings-whisper-benchmark-status'),
+          settingsWhisperBenchmarkRun: document.getElementById('settings-whisper-benchmark-run'),
+          settingsWhisperModelUninstall: document.getElementById('settings-whisper-model-uninstall'),
+          settingsWhisperModelUninstallRun: document.getElementById('settings-whisper-model-uninstall-run'),
           settingsCloudConnectionEnabled: document.getElementById(
             'settings-cloud-connection-enabled',
           ),
@@ -13978,6 +14018,67 @@
           } finally {
             if (dom.settingsCloudConnectionTest) {
               dom.settingsCloudConnectionTest.disabled = false;
+            }
+          }
+        }
+
+        async function runWhisperBenchmark() {
+          if (!dom.settingsWhisperBenchmarkRun) {
+            return;
+          }
+          dom.settingsWhisperBenchmarkRun.disabled = true;
+          if (dom.settingsWhisperBenchmarkStatus) {
+            dom.settingsWhisperBenchmarkStatus.textContent = 'Benchmark running…';
+          }
+          try {
+            const response = await request('/api/settings/whisper/benchmark', { method: 'POST' });
+            const rows = Array.isArray(response?.results) ? response.results : [];
+            const summary = rows
+              .map((row) => {
+                if (row?.ok) {
+                  return `${row.model}: ${row.seconds}s`;
+                }
+                return `${row?.model ?? 'unknown'}: failed`;
+              })
+              .join(' • ');
+            const recommendation = response?.recommended_model
+              ? ` Best: ${response.recommended_model}.`
+              : '';
+            if (dom.settingsWhisperBenchmarkStatus) {
+              dom.settingsWhisperBenchmarkStatus.textContent = `${summary || 'No benchmark results.'}${recommendation}`;
+            }
+            showStatus('Whisper benchmark completed.', 'success');
+          } catch (error) {
+            const detail = error instanceof Error ? error.message : 'Benchmark failed.';
+            if (dom.settingsWhisperBenchmarkStatus) {
+              dom.settingsWhisperBenchmarkStatus.textContent = detail;
+            }
+            showStatus(detail, 'error');
+          } finally {
+            dom.settingsWhisperBenchmarkRun.disabled = false;
+          }
+        }
+
+        async function uninstallWhisperModel() {
+          const model = dom.settingsWhisperModelUninstall?.value || 'base';
+          if (!model) {
+            return;
+          }
+          if (dom.settingsWhisperModelUninstallRun) {
+            dom.settingsWhisperModelUninstallRun.disabled = true;
+          }
+          try {
+            const response = await request(`/api/settings/whisper-models/${encodeURIComponent(model)}`, {
+              method: 'DELETE',
+            });
+            const removedCount = Array.isArray(response?.removed) ? response.removed.length : 0;
+            showStatus(`Removed ${removedCount} file(s) for model ${model}.`, 'success');
+          } catch (error) {
+            const detail = error instanceof Error ? error.message : 'Model uninstall failed.';
+            showStatus(detail, 'error');
+          } finally {
+            if (dom.settingsWhisperModelUninstallRun) {
+              dom.settingsWhisperModelUninstallRun.disabled = false;
             }
           }
         }
@@ -22691,6 +22792,18 @@
         if (dom.settingsVisualEffects) {
           dom.settingsVisualEffects.addEventListener('change', () => {
             previewAppearance();
+          });
+        }
+
+        if (dom.settingsWhisperBenchmarkRun) {
+          dom.settingsWhisperBenchmarkRun.addEventListener('click', async () => {
+            await runWhisperBenchmark();
+          });
+        }
+
+        if (dom.settingsWhisperModelUninstallRun) {
+          dom.settingsWhisperModelUninstallRun.addEventListener('click', async () => {
+            await uninstallWhisperModel();
           });
         }
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2616,3 +2616,56 @@ def test_reveal_asset_uses_helper(monkeypatch, temp_config):
     assert response.status_code == 204
     assert calls["path"] == target_file.resolve()
     assert calls["select"] is True
+
+def test_whisper_model_uninstall_endpoint_removes_model_files(temp_config):
+    repository = LectureRepository(temp_config)
+    app = create_app(repository, config=temp_config)
+    client = TestClient(app)
+
+    model_dir = temp_config.assets_root / "models"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    target = model_dir / "ggml-base.bin"
+    target.write_bytes(b"model")
+
+    response = client.delete("/api/settings/whisper-models/base")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["model"] == "base"
+    assert any(path.endswith("ggml-base.bin") for path in payload["removed"])
+    assert not target.exists()
+
+
+def test_whisper_benchmark_endpoint_runs_all_models_with_stub_engine(temp_config, monkeypatch):
+    repository = LectureRepository(temp_config)
+
+    benchmark_audio = temp_config.assets_root / "benchmarks" / "public_domain_sample.mp3"
+    benchmark_audio.parent.mkdir(parents=True, exist_ok=True)
+    benchmark_audio.write_bytes(b"audio")
+
+    class StubEngine:
+        def __init__(self, model_size, **_kwargs):
+            self.model_size = model_size
+
+        def transcribe(self, _audio_path, output_dir):
+            output_dir.mkdir(parents=True, exist_ok=True)
+            transcript = output_dir / "transcript.txt"
+            transcript.write_text(f"model={self.model_size}", encoding="utf-8")
+            return TranscriptResult(text=f"model={self.model_size}", transcript_path=transcript)
+
+    monkeypatch.setattr(web_server, "FasterWhisperTranscription", StubEngine)
+
+    app = create_app(repository, config=temp_config)
+    client = TestClient(app)
+
+    response = client.post("/api/settings/whisper/benchmark")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["sample"]["path"] == "benchmarks/public_domain_sample.mp3"
+    assert len(payload["results"]) == 5
+    assert {row["model"] for row in payload["results"]} == {
+        "tiny",
+        "base",
+        "small",
+        "medium",
+        "large",
+    }


### PR DESCRIPTION
### Motivation
- Reduce local/cloud sync drift and make processing robust by retrying cloud uploads and surfacing reliable operations for production use.
- Provide a simple benchmark to help pick an appropriate Whisper model on deployed servers using a small public-domain sample.
- Allow reclaiming disk space by uninstalling local Whisper model files from the UI.

### Description
- Added resilient cloud upload logic with retries and backoff in `_upload_cloud_asset` to reduce transient failures when syncing processed assets. 
- Introduced Whisper benchmark constants, a bootstrap download helper, and model discovery helpers, plus `POST /api/settings/whisper/benchmark` to run tiny/base/small/medium/large on a bundled public-domain sample and return timing/results. 
- Added `DELETE /api/settings/whisper-models/{model_name}` to remove local model files and reclaim space, and helpers to locate model files under `assets/models`. 
- Updated the settings UI (`index.html`) to include benchmark and uninstall controls, translations, and client-side wiring to call the new endpoints and display results. 
- Added API tests for the uninstall and benchmark endpoints and small server-side helpers in `app/web/server.py` to support these features. 

### Testing
- Ran targeted API tests: `pytest -q tests/test_web_api.py -k 'whisper_model_uninstall or whisper_benchmark_endpoint_runs_all_models'` and they passed. 
- Verified Python compilation for the modified server module with `python -m py_compile app/web/server.py` which succeeded. 
- Performed a CLI smoke check with `python run.py --help` and a headless UI smoke capture via an automated Playwright script that exercised the settings page and produced a screenshot of the new controls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d690d11883309b71f553aa257faf)