### PR TITLE
Add inline transcript editor and API to create/update transcript text

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -230,6 +230,7 @@ class TaskQueue:
                 await worker
         return cancelled
 
+
 from fastapi import (
     FastAPI,
     HTTPException,
@@ -1869,6 +1870,10 @@ class LectureReorderEntry(BaseModel):
 
 class LectureReorderPayload(BaseModel):
     modules: List[LectureReorderEntry] = Field(default_factory=list)
+
+
+class TranscriptUpdateRequest(BaseModel):
+    text: str = Field(default="")
 
 
 class TranscriptionRequest(BaseModel):
@@ -4856,6 +4861,61 @@ def create_app(
             path=relative,
         )
         return response
+
+    @app.put("/api/lectures/{lecture_id}/assets/transcript")
+    async def upsert_transcript_text(
+        lecture_id: int,
+        payload: TranscriptUpdateRequest,
+    ) -> Dict[str, Any]:
+        _log_event("Saving transcript text", lecture_id=lecture_id)
+        lecture = repository.get_lecture(lecture_id)
+        if lecture is None:
+            raise HTTPException(status_code=404, detail="Lecture not found")
+
+        class_record, module = _require_hierarchy(lecture)
+        storage_root = _require_storage_root()
+        lecture_paths = LecturePaths.build(
+            storage_root,
+            class_record.name,
+            module.name,
+            lecture.name,
+        )
+        lecture_paths.ensure()
+        lecture_paths.transcript_dir.mkdir(parents=True, exist_ok=True)
+
+        text_value = payload.text if isinstance(payload.text, str) else ""
+        transcript_relative = lecture.transcript_path
+        target: Optional[Path] = None
+        existed_before = False
+
+        if transcript_relative:
+            existing = _resolve_asset_path(transcript_relative)
+            if existing is not None:
+                target = existing
+                existed_before = existing.exists()
+            else:
+                transcript_relative = None
+
+        if target is None:
+            stem = build_asset_stem(class_record.name, module.name, lecture.name, "transcript")
+            filename = build_timestamped_name(stem, extension=".txt")
+            target = lecture_paths.transcript_dir / filename
+            transcript_relative = target.relative_to(storage_root).as_posix()
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text_value, encoding="utf-8")
+
+        repository.update_lecture_assets(lecture_id, transcript_path=transcript_relative)
+        updated = repository.get_lecture(lecture_id)
+        if updated is None:
+            raise HTTPException(status_code=500, detail="Lecture update failed")
+        lecture_payload = _serialize_lecture(updated)
+
+        return {
+            "lecture": lecture_payload,
+            "transcript_path": transcript_relative,
+            "created": not existed_before,
+        }
 
     @app.delete("/api/lectures/{lecture_id}/assets/{asset_type}")
     async def delete_asset(lecture_id: int, asset_type: str) -> Dict[str, Any]:

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -2223,6 +2223,14 @@
       .upload-dialog-hidden {
         display: none !important;
       }
+      .transcript-edit-window {
+        width: min(760px, 92vw);
+      }
+      .transcript-edit-area {
+        width: 100%;
+        min-height: 320px;
+        resize: vertical;
+      }
 
       .bulk-upload-window {
         width: min(460px, 100%);
@@ -6057,6 +6065,25 @@
         </div>
       </div>
     </div>
+    <div id="transcript-edit-dialog" class="dialog hidden" aria-hidden="true" tabindex="-1">
+      <div id="transcript-edit-backdrop" class="dialog-backdrop"></div>
+      <div
+        id="transcript-edit-window"
+        class="dialog-window transcript-edit-window"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="transcript-edit-title"
+      >
+        <div class="dialog-header">
+          <h2 id="transcript-edit-title" class="dialog-title"></h2>
+        </div>
+        <textarea id="transcript-edit-text" class="transcript-edit-area"></textarea>
+        <div class="dialog-actions">
+          <button id="transcript-edit-discard" type="button" class="secondary"></button>
+          <button id="transcript-edit-save" type="button"></button>
+        </div>
+      </div>
+    </div>
     <div id="bulk-upload-dialog" class="dialog hidden" aria-hidden="true" tabindex="-1">
       <div id="bulk-upload-backdrop" class="dialog-backdrop"></div>
       <div
@@ -6293,11 +6320,17 @@
               },
               actions: {
                 upload: 'Upload',
+                edit: 'Edit',
                 processSlides: 'Process slides',
                 view: 'View',
                 download: 'Download',
                 remove: 'Remove',
               },
+            },
+            transcriptEditor: {
+              title: 'Edit transcript',
+              save: 'Save',
+              discard: 'Discard',
             },
             tasks: {
               title: 'Tasks',
@@ -6900,6 +6933,9 @@
               processingSlides: 'Processing slides…',
               audioProcessingQueued: 'Audio uploaded. Mastering will continue in the background.',
               assetUploaded: 'Asset uploaded successfully.',
+              transcriptCreated: 'Transcript saved as a new text file.',
+              transcriptUpdated: 'Transcript updated.',
+              transcriptEditDiscarded: 'Transcript edit discarded.',
               assetRemoved: 'Asset removed.',
               transcriptionPreparing: '====> Preparing transcription…',
               transcriptionCompleted: 'Transcription completed.',
@@ -9978,6 +10014,15 @@
             status: document.getElementById('upload-status-message'),
             cancel: document.getElementById('upload-cancel'),
             confirm: document.getElementById('upload-confirm'),
+          },
+          transcriptEditDialog: {
+            root: document.getElementById('transcript-edit-dialog'),
+            backdrop: document.getElementById('transcript-edit-backdrop'),
+            window: document.getElementById('transcript-edit-window'),
+            title: document.getElementById('transcript-edit-title'),
+            text: document.getElementById('transcript-edit-text'),
+            discard: document.getElementById('transcript-edit-discard'),
+            save: document.getElementById('transcript-edit-save'),
           },
           bulkUploadDialog: {
             root: document.getElementById('bulk-upload-dialog'),
@@ -21688,6 +21733,16 @@
               });
               actions.appendChild(uploadButton);
             }
+            if (definition.type === 'transcript') {
+              const editButton = document.createElement('button');
+              editButton.type = 'button';
+              editButton.className = 'secondary';
+              editButton.textContent = t('assets.actions.edit');
+              editButton.addEventListener('click', () => {
+                handleTranscriptEdit(definition);
+              });
+              actions.appendChild(editButton);
+            }
 
             if (definition.type === 'audio') {
               transcribeButton = document.createElement('button');
@@ -22088,6 +22143,85 @@
           if (kind === 'audio' && audioProcessingStarted && !backgroundProcessingActive) {
             stopProcessingProgress({ preserveMessage: true });
             audioProcessingStarted = false;
+          }
+        }
+
+        function showTranscriptEditDialog(initialText) {
+          return new Promise((resolve) => {
+            const dialog = dom.transcriptEditDialog;
+            if (!dialog?.root || !dialog.window || !dialog.text || !dialog.save || !dialog.discard) {
+              resolve({ action: 'discard' });
+              return;
+            }
+
+            dialog.title.textContent = t('transcriptEditor.title');
+            dialog.save.textContent = t('transcriptEditor.save');
+            dialog.discard.textContent = t('transcriptEditor.discard');
+            dialog.text.value = typeof initialText === 'string' ? initialText : '';
+
+            const cleanup = (result) => {
+              dialog.save.removeEventListener('click', onSave);
+              dialog.discard.removeEventListener('click', onDiscard);
+              dialog.backdrop?.removeEventListener('click', onDiscard);
+              dialog.window.removeEventListener('keydown', onKeyDown);
+              dialog.root.classList.add('hidden');
+              dialog.root.setAttribute('aria-hidden', 'true');
+              dialogState.active = false;
+              document.body.classList.remove('dialog-open');
+              resolve(result);
+            };
+            const onSave = () => cleanup({ action: 'save', text: dialog.text.value || '' });
+            const onDiscard = () => cleanup({ action: 'discard' });
+            const onKeyDown = (event) => {
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                onDiscard();
+              }
+            };
+            dialog.save.addEventListener('click', onSave);
+            dialog.discard.addEventListener('click', onDiscard);
+            dialog.backdrop?.addEventListener('click', onDiscard);
+            dialog.window.addEventListener('keydown', onKeyDown);
+            dialog.root.classList.remove('hidden');
+            dialog.root.setAttribute('aria-hidden', 'false');
+            dialogState.active = true;
+            document.body.classList.add('dialog-open');
+            window.setTimeout(() => dialog.text.focus(), 10);
+          });
+        }
+
+        async function handleTranscriptEdit(definition) {
+          if (!definition || !state.selectedLectureId) {
+            return;
+          }
+          const lectureId = state.selectedLectureId;
+          const detail = state.selectedLectureDetail?.lecture;
+          const transcriptPath = detail?.transcript_path;
+          let existingText = '';
+          if (transcriptPath) {
+            try {
+              existingText = await request(`/api/storage/file?path=${encodeURIComponent(transcriptPath)}`);
+            } catch (error) {
+              showStatus(error.message, 'error');
+              return;
+            }
+          }
+          const result = await showTranscriptEditDialog(existingText);
+          if (!result || result.action !== 'save') {
+            showStatus(t('status.transcriptEditDiscarded'), 'info');
+            return;
+          }
+          try {
+            const response = await request(`/api/lectures/${lectureId}/assets/transcript`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ text: result.text || '' }),
+            });
+            showStatus(response?.created ? t('status.transcriptCreated') : t('status.transcriptUpdated'), 'success');
+            await refreshData();
+            await selectLecture(lectureId);
+          } catch (error) {
+            showStatus(error.message, 'error');
           }
         }
 


### PR DESCRIPTION
### Motivation

- Provide a way for users to edit or enter lecture transcripts directly in the UI without requiring file upload.
- Keep a simple, consistent UX so Save writes (creates/updates) a .txt transcript and Discard closes the editor without writing.

### Description

- Added a new API endpoint `PUT /api/lectures/{lecture_id}/assets/transcript` with a `TranscriptUpdateRequest` payload to create or update a transcript file and update the lecture record (reuses existing transcript path when present, otherwise creates a timestamped `.txt`).
- Implemented server-side upsert logic to resolve existing transcript paths, create directories, write UTF-8 text, and update the repository (`app/web/server.py`).
- Added UI elements: editor dialog markup, CSS, DOM references, i18n strings, and an `Edit` button for transcript assets placed between Upload and Download in the assets action row (`app/web/templates/index.html`).
- Implemented dialog behavior and wiring: load existing transcript text into the editor when present, provide `Save` (persists via the new API) and `Discard` (closes without writing) actions, Escape/backdrop handling, and success/info notifications for created/updated/discarded flows.

### Testing

- Ran `pytest -q tests/test_web_api.py`; the test run failed with many failures due to an environment/framework mismatch (an `AttributeError` raised during app creation: `FastAPI` object has no attribute `add_event_handler`), so endpoint-level assertions did not complete.
- No other automated tests were executed in this rollout; manual exercise of the UI/endpoint was not performed as part of the automated run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37a71e1488330bc71d1562e8c796a)