### PR TITLE
Merge transcript view/edit flows and show Create when missing

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -6323,6 +6323,7 @@
                 edit: 'Edit',
                 processSlides: 'Process slides',
                 view: 'View',
+                create: 'Create',
                 download: 'Download',
                 remove: 'Remove',
               },
@@ -7055,6 +7056,7 @@
                 upload: '上传',
                 processSlides: '处理课件',
                 view: '查看',
+                create: '创建',
                 download: '下载',
                 remove: '移除',
               },
@@ -7758,6 +7760,7 @@
                 upload: 'Subir',
                 processSlides: 'Procesar diapositivas',
                 view: 'Ver',
+                create: 'Crear',
                 download: 'Descargar',
                 remove: 'Eliminar',
               },
@@ -8481,6 +8484,7 @@
                 upload: 'Importer',
                 processSlides: 'Traiter les diapositives',
                 view: 'Voir',
+                create: 'Créer',
                 download: 'Télécharger',
                 remove: 'Supprimer',
               },
@@ -21733,16 +21737,6 @@
               });
               actions.appendChild(uploadButton);
             }
-            if (definition.type === 'transcript') {
-              const editButton = document.createElement('button');
-              editButton.type = 'button';
-              editButton.className = 'secondary';
-              editButton.textContent = t('assets.actions.edit');
-              editButton.addEventListener('click', () => {
-                handleTranscriptEdit(definition);
-              });
-              actions.appendChild(editButton);
-            }
 
             if (definition.type === 'audio') {
               transcribeButton = document.createElement('button');
@@ -21785,7 +21779,19 @@
 
             const viewTarget = effectiveValue;
             const viewable = Boolean(viewTarget && isAssetViewable(definition, viewTarget));
-            if (viewable) {
+            if (definition.type === 'transcript') {
+              const hasTranscript = Boolean(value);
+              const transcriptButton = document.createElement('button');
+              transcriptButton.type = 'button';
+              transcriptButton.className = 'secondary';
+              transcriptButton.textContent = hasTranscript
+                ? t('assets.actions.view')
+                : t('assets.actions.create');
+              transcriptButton.addEventListener('click', () => {
+                handleTranscriptEdit(definition);
+              });
+              actions.appendChild(transcriptButton);
+            } else if (viewable) {
               const viewButton = document.createElement('button');
               viewButton.type = 'button';
               viewButton.className = 'secondary';


### PR DESCRIPTION
### Motivation
- Users reported the transcript "Edit" flow failing when a transcript text file already existed and the UI exposed confusing/duplicated actions for transcripts; the change aims to unify the transcript UX so a single button opens the same editor dialog and its label reflects whether a transcript is present.

### Description
- Reworked asset action rendering in `app/web/templates/index.html` to remove the separate transcript-specific "Edit" button and instead render a single button for transcripts that is labeled `View` when a transcript file exists and `Create` when it does not. 
- The single transcript button now opens the existing transcript editor dialog (`showTranscriptEditDialog` / `handleTranscriptEdit`) for both viewing/editing and creating, keeping the same save/discard flow. 
- Added/confirmed localized `assets.actions.create` entries for supported languages so the new label shows in the UI (English, Chinese, Spanish, French). 
- Change is limited to the client-side template: `app/web/templates/index.html`.

### Testing
- Ran the web API test suite invocation `pytest -q tests/test_web_api.py -q`, which could not complete due to a pre-existing compatibility issue in this environment causing an `AttributeError: 'FastAPI' object has no attribute 'add_event_handler'` and produced failures before reaching feature-level assertions, so automated tests did not validate the UI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39fe2cd008330ad52ac34058cec4c)