### PR TITLE
Strip optional leading `storage/` from stored paths so existing transcript .txt can be viewed

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -1587,6 +1587,10 @@ def _normalize_storage_relative_path(value: str) -> str:
     cleaned = cleaned.replace("\\", "/")
     while cleaned.startswith("/"):
         cleaned = cleaned[1:]
+    if cleaned == "storage":
+        return ""
+    if cleaned.startswith("storage/"):
+        cleaned = cleaned[len("storage/") :]
     return cleaned
 
 


### PR DESCRIPTION
### Motivation
- Existing transcript records sometimes include a leading `storage/` segment which caused the `/storage/{path}` resolver to look up `<storage_root>/storage/...` and return "File not found", preventing viewing of existing `.txt` transcripts.

### Description
- Update `_normalize_storage_relative_path` in `app/web/server.py` to treat a literal `storage` as an empty relative path and to strip a leading `storage/` prefix so legacy `storage/...` asset paths resolve to the actual files under the configured storage root.

### Testing
- Ran a small Python sanity check calling `_normalize_storage_relative_path` and verified inputs like `storage/a/b.txt`, `/storage/a/b.txt`, `a/b.txt`, and `storage` map to the intended normalized values.
- Ran `pytest -q tests/test_web_api.py`, which failed in this environment due to an unrelated FastAPI API incompatibility (`FastAPI` missing `add_event_handler`), not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a17537fc8330a7969f86f9bd7891)