### PR TITLE
Fix transcript viewer for storage-prefixed asset paths

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -18451,7 +18451,14 @@
           if (!path) {
             return '#';
           }
-          const encodedPath = path
+          const normalizedPath = String(path)
+            .trim()
+            .replace(/^\/+/, '')
+            .replace(/^storage\/+/i, '');
+          if (!normalizedPath) {
+            return '#';
+          }
+          const encodedPath = normalizedPath
             .split('/')
             .map((segment) => encodeURIComponent(segment))
             .join('/');


### PR DESCRIPTION
### Motivation
- Viewing existing transcript `.txt` assets that were stored with a leading `storage/` (or leading slash) produced URLs like `/storage/storage/...`, causing a "not found" error when clicking `View` in the asset viewer.

### Description
- Normalize the asset path in `buildStorageURL` (in `app/web/templates/index.html`) by trimming whitespace and leading slashes and stripping an optional leading `storage/` prefix before encoding segments and building the `/storage/...` URL, returning `'#'` for empty normalized paths.

### Testing
- Ran `pytest -q tests/test_web_api.py -k "static_storage_respects_root_path"`, which exercised storage-related functionality but the run failed with an unrelated `AttributeError` (`FastAPI` missing `add_event_handler`) in this environment, not caused by the template change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a7f39cc88330962db19cc9f09e5c)